### PR TITLE
fix: fix local parameter check

### DIFF
--- a/biosimulators_utils/model_lang/sbml/utils.py
+++ b/biosimulators_utils/model_lang/sbml/utils.py
@@ -514,7 +514,7 @@ def get_parameters_variables_outputs_for_simulation(model_filename, model_langua
                         ).format(reaction_id, param_id)
 
                     params.append(ModelAttributeChange(
-                        id=param_id if native_ids else 'value_parameter_' + param_id,
+                        id=param_id if native_ids else 'value_parameter_' reaction_id + '_' + param_id,
                         name=parameter.getName() or None if native_ids else 'Value of parameter "{}" of reaction "{}"'.format(
                             parameter.getName() or param_id, reaction.getName() or reaction_id),
                         target=target,
@@ -529,7 +529,7 @@ def get_parameters_variables_outputs_for_simulation(model_filename, model_langua
                         and model.getAssignmentRuleByVariable(param_id)
                     ):
                         var = Variable(
-                            id=param_id if native_ids else 'value_parameter_' + param_id,
+                            id=param_id if native_ids else 'value_parameter_' + reaction_id + '_' + param_id,
                             name=parameter.getName() or None if native_ids else 'Value of parameter "{}" of reaction "{}"'.format(
                                 parameter.getName() or param_id, reaction.getName() or reaction_id),
                             target=target,

--- a/biosimulators_utils/model_lang/sbml/utils.py
+++ b/biosimulators_utils/model_lang/sbml/utils.py
@@ -526,7 +526,6 @@ def get_parameters_variables_outputs_for_simulation(model_filename, model_langua
                         include_model_parameters_in_simulation_variables
                         and parameter.isSetConstant()
                         and not parameter.getConstant()
-                        and model.getAssignmentRuleByVariable(param_id)
                     ):
                         var = Variable(
                             id=param_id if native_ids else 'value_parameter_' + reaction_id + '_' + param_id,

--- a/biosimulators_utils/model_lang/sbml/utils.py
+++ b/biosimulators_utils/model_lang/sbml/utils.py
@@ -513,15 +513,14 @@ def get_parameters_variables_outputs_for_simulation(model_filename, model_langua
                             "/sbml:listOfParameters/sbml:parameter[@id='{}']/@value"
                         ).format(reaction_id, param_id)
 
-                    if not model.getInitialAssignmentBySymbol(param_id) and not model.getAssignmentRuleByVariable(param_id):
-                        params.append(ModelAttributeChange(
-                            id=param_id if native_ids else 'value_parameter_' + param_id,
-                            name=parameter.getName() or None if native_ids else 'Value of parameter "{}" of reaction "{}"'.format(
-                                parameter.getName() or param_id, reaction.getName() or reaction_id),
-                            target=target,
-                            target_namespaces=namespaces,
-                            new_value=parameter.getValue() if native_data_types else format_float(parameter.getValue()),
-                        ))
+                    params.append(ModelAttributeChange(
+                        id=param_id if native_ids else 'value_parameter_' + param_id,
+                        name=parameter.getName() or None if native_ids else 'Value of parameter "{}" of reaction "{}"'.format(
+                            parameter.getName() or param_id, reaction.getName() or reaction_id),
+                        target=target,
+                        target_namespaces=namespaces,
+                        new_value=parameter.getValue() if native_data_types else format_float(parameter.getValue()),
+                    ))
 
                     if (
                         include_model_parameters_in_simulation_variables


### PR DESCRIPTION
Local parameters can't have initial assignments nor assignment rules.  Checking to see if they do actually introduces a subtle bug:  if the model has a global parameter (or species, etc.) with the same ID as a local parameter that *did* have an assignment, this check would find that and mistakenly attribute it to the local parameter.
