### PR TITLE
Clarify warning about limited support for plotting results of repeated tasks

### DIFF
--- a/biosimulators_utils/sedml/validation.py
+++ b/biosimulators_utils/sedml/validation.py
@@ -1582,7 +1582,8 @@ def validate_output(output):
 
     if involves_repeated_task:
         msg = (
-            'Some simulation tools will not be able to generate this output because it uses data from repeated tasks. '
+            'Some simulation tools will not be able to generate this output because it uses data from repeated tasks, '
+            'which some simulation tools do not have the capability to execute.'
         )
         warnings.append([msg])
 

--- a/biosimulators_utils/sedml/validation.py
+++ b/biosimulators_utils/sedml/validation.py
@@ -1583,7 +1583,6 @@ def validate_output(output):
     if involves_repeated_task:
         msg = (
             'Some simulation tools will not be able to generate this output because it uses data from repeated tasks. '
-            'Output for repeated tasks is an experimental feature of SED-ML, which is not officially supported.'
         )
         warnings.append([msg])
 


### PR DESCRIPTION
Output from repeated tasks has been a supported feature of SED-ML since 2017.  Simulators may not have picked up support for it until later, but it was never 'experimental'.  Some tools don't support it; we can leave it at that.