### PR TITLE
Fix for #96: consolidate warnings

### DIFF
--- a/biosimulators_utils/__main__.py
+++ b/biosimulators_utils/__main__.py
@@ -203,7 +203,7 @@ class ValidateModelController(cement.Controller):
         errors, warnings, _ = biosimulators_utils.sedml.validation.validate_model_with_language(filename, language, config=config)
 
         if warnings:
-            msg = 'The model file `{}` may be invalid.\n  {}'.format(
+            msg = 'The model file `{}` has warnings.\n  {}'.format(
                 filename, flatten_nested_list_of_strings(warnings).replace('\n', '\n  '))
             warn(msg, BioSimulatorsWarning)
 
@@ -249,7 +249,7 @@ class ValidateSimulationController(cement.Controller):
                 raise
 
         if reader.warnings:
-            msg = 'The SED-ML file `{}` may be invalid.\n  {}'.format(
+            msg = 'The SED-ML file `{}` has warnings.\n  {}'.format(
                 args.filename, flatten_nested_list_of_strings(reader.warnings).replace('\n', '\n  '))
             warn(msg, BioSimulatorsWarning)
 
@@ -289,7 +289,7 @@ class ValidateMetadataController(cement.Controller):
         _, errors, warnings = biosimulators_utils.omex_meta.io.read_omex_meta_file(args.filename)
 
         if warnings:
-            msg = 'The OMEX Metadata file `{}` may be invalid.\n  {}'.format(
+            msg = 'The OMEX Metadata file `{}` has warnings.\n  {}'.format(
                 args.filename, flatten_nested_list_of_strings(warnings).replace('\n', '\n  '))
             warn(msg, BioSimulatorsWarning)
 
@@ -345,7 +345,7 @@ class ValidateModelingProjectController(cement.Controller):
             config=config,
         )
         if warnings:
-            msg = 'The COMBINE/OMEX archive may be invalid.\n  {}'.format(
+            msg = 'The COMBINE/OMEX archive has warnings.\n  {}'.format(
                 flatten_nested_list_of_strings(warnings).replace('\n', '\n  '))
             warn(msg, BioSimulatorsWarning)
 

--- a/biosimulators_utils/combine/exec.py
+++ b/biosimulators_utils/combine/exec.py
@@ -125,7 +125,7 @@ def exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, appl
             # validate archive
             errors, warnings = validate(archive, archive_tmp_dir, config=config)
             if warnings:
-                msg = 'The COMBINE/OMEX archive may be invalid.\n  {}'.format(
+                msg = 'The COMBINE/OMEX archive has warnings.\n  {}'.format(
                     flatten_nested_list_of_strings(warnings).replace('\n', '\n  '))
                 warn(msg, BioSimulatorsWarning)
 

--- a/biosimulators_utils/combine/io.py
+++ b/biosimulators_utils/combine/io.py
@@ -78,7 +78,7 @@ class CombineArchiveWriter(object):
         self.warnings.extend(warnings)
 
         if self.warnings:
-            warn('COMBINE/OMEX archive may be invalid.\n  ' + flatten_nested_list_of_strings(self.warnings).replace('\n', '\n  '),
+            warn('COMBINE/OMEX archive has warnings.\n  ' + flatten_nested_list_of_strings(self.warnings).replace('\n', '\n  '),
                  BioSimulatorsWarning)
         if self.errors:
             raise ValueError('COMBINE/OMEX archive is invalid.\n  ' + flatten_nested_list_of_strings(self.errors).replace('\n', '\n  '))
@@ -105,7 +105,7 @@ class CombineArchiveWriter(object):
 
         errors, warnings = get_combine_errors_warnings(manifest)
         if warnings:
-            msg = 'COMBINE/OMEX archive may be invalid.\n  ' + flatten_nested_list_of_strings(warnings).replace('\n', '\n  ')
+            msg = 'COMBINE/OMEX archive has warnings.\n  ' + flatten_nested_list_of_strings(warnings).replace('\n', '\n  ')
             warn(msg, BioSimulatorsWarning)
         if errors:
             msg = 'COMBINE/OMEX archive is invalid.\n  ' + flatten_nested_list_of_strings(errors).replace('\n', '\n  ')
@@ -237,7 +237,7 @@ class CombineArchiveReader(object):
 
         # raise warnings and errors
         if self.warnings:
-            warn('COMBINE/OMEX archive may be invalid.\n  ' + flatten_nested_list_of_strings(self.warnings).replace('\n', '\n  '),
+            warn('COMBINE/OMEX archive has warnings.\n  ' + flatten_nested_list_of_strings(self.warnings).replace('\n', '\n  '),
                  BioSimulatorsWarning)
         if self.errors:
             raise ValueError('`{}` is not a valid COMBINE/OMEX archive.\n  {}'.format(

--- a/biosimulators_utils/combine/validation.py
+++ b/biosimulators_utils/combine/validation.py
@@ -281,7 +281,7 @@ def validate_content(content, archive_dirname,
         ]]
     if warnings:
         warnings = [[
-            'The {} file at location `{}` may be invalid.'.format(file_type, content.location),
+            'The {} file at location `{}` has warnings.'.format(file_type, content.location),
             warnings,
         ]]
 

--- a/biosimulators_utils/model_lang/sbml/validation.py
+++ b/biosimulators_utils/model_lang/sbml/validation.py
@@ -37,19 +37,33 @@ def validate_model(filename, name=None, validate_consistency=True, config=None):
             if validate_consistency:
                 doc.checkConsistency()
 
-            warningmap = {}
+            warning_map = {}
             for i_error in range(doc.getNumErrors()):
                 sbml_error = doc.getError(i_error)
                 if sbml_error.isInfo() or sbml_error.isWarning():
-                    errid = sbml_error.getErrorId()
-                    if errid not in warningmap:
-                        warningmap[errid] = [0, sbml_error.getMessage()]
-                    warningmap[errid][0] += 1
+                    err_id = sbml_error.getErrorId()
+                    if err_id not in warning_map:
+                        warning_map[err_id] = [
+                            0,
+                            sbml_error.getCategoryAsString(),
+                            sbml_error.getMessage().strip(),
+                            sbml_error.getLine(),
+                            sbml_error.getColumn(),
+                            sbml_error.getSeverityAsString().lower(),
+                        ]
+                    warning_map[err_id][0] += 1
                 else:
-                    errors.append([sbml_error.getMessage()])
-            for errid in warningmap:
-                (num, msg) = warningmap[errid]
-                warnings.append([str(num) + " SBML warning(s) with id " + str(errid) + ".  Example message:\n'" + msg.strip() + "'"])
+                    errors.append(['{} ({}) at line {}, column {}: {}'.format(
+                        sbml_error.getCategoryAsString(), sbml_error.getErrorId(),
+                        sbml_error.getLine(), sbml_error.getColumn(),
+                        sbml_error.getMessage())
+                    ])
+            for err_id, (count, category, first_msg, line, column, severity) in warning_map.items():
+                warnings.append([
+                    '{} {}{} of type {} ({}). The following is the first {} at line {}, column {}:'.format(
+                        count, severity, 's' if count > 1 else '', category, err_id, severity, line, column),
+                    [[first_msg]]
+                ])
 
         else:
             errors.append(['`{}` is not a file.'.format(filename or '')])

--- a/biosimulators_utils/model_lang/sbml/validation.py
+++ b/biosimulators_utils/model_lang/sbml/validation.py
@@ -37,12 +37,19 @@ def validate_model(filename, name=None, validate_consistency=True, config=None):
             if validate_consistency:
                 doc.checkConsistency()
 
+            warningmap = {}
             for i_error in range(doc.getNumErrors()):
                 sbml_error = doc.getError(i_error)
                 if sbml_error.isInfo() or sbml_error.isWarning():
-                    warnings.append([sbml_error.getMessage()])
+                    errid = sbml_error.getErrorId()
+                    if errid not in warningmap:
+                        warningmap[errid] = [0, sbml_error.getMessage()]
+                    warningmap[errid][0] += 1
                 else:
                     errors.append([sbml_error.getMessage()])
+            for errid in warningmap:
+                (num, msg) = warningmap[errid]
+                warnings.append([str(num) + " SBML warning(s) with id " + str(errid) + ".  Example message:\n'" + msg.strip() + "'"])
 
         else:
             errors.append(['`{}` is not a file.'.format(filename or '')])

--- a/biosimulators_utils/omex_meta/io.py
+++ b/biosimulators_utils/omex_meta/io.py
@@ -340,7 +340,7 @@ class TriplesOmexMetaReader(OmexMetaReader):
 
             if temp_warnings:
                 if isinstance(filename_or_filenames, (tuple, list)):
-                    warnings.append(['The OMEX Metadata file at location `{}` may be invalid.'.format(error_filename), temp_warnings])
+                    warnings.append(['The OMEX Metadata file at location `{}` has warnings.'.format(error_filename), temp_warnings])
                 else:
                     warnings.extend(temp_warnings)
 
@@ -503,7 +503,7 @@ class BiosimulationsOmexMetaReader(OmexMetaReader):
 
             if temp_warnings:
                 if isinstance(filename_or_filenames, (tuple, list)):
-                    warnings.append(['The OMEX Metadata file at location `{}` may be invalid.'.format(error_filename), temp_warnings])
+                    warnings.append(['The OMEX Metadata file at location `{}` has warnings.'.format(error_filename), temp_warnings])
                 else:
                     warnings.extend(temp_warnings)
 

--- a/biosimulators_utils/omex_meta/validation.py
+++ b/biosimulators_utils/omex_meta/validation.py
@@ -53,7 +53,7 @@ def validate_biosimulations_metadata(metadata, archive=None, working_dir=None):
 
         if temp_warnings:
             el_uri = get_global_combine_archive_content_uri(el_metadata['uri'], el_metadata['combine_archive_uri'])
-            warnings.append(['The metadata for URI `{}` may be invalid.'.format(
+            warnings.append(['The metadata for URI `{}` has warnings.'.format(
                 el_uri),  temp_warnings])
 
     if not has_archive_metadata:

--- a/biosimulators_utils/sedml/data_model.py
+++ b/biosimulators_utils/sedml/data_model.py
@@ -10,6 +10,7 @@ from ..biosimulations.data_model import Metadata  # noqa: F401
 from ..utils.core import are_lists_equal, none_sorted
 import abc
 import enum
+import libsedml
 
 
 __all__ = [
@@ -578,7 +579,6 @@ class Model(SedBase, SedIdGroupMixin):
         self.source = source
         self.language = language
         self.changes = changes or []
-        self.structural_changes = []
 
     def to_tuple(self):
         """ Get a tuple representation
@@ -604,6 +604,18 @@ class Model(SedBase, SedIdGroupMixin):
             and self.language == other.language \
             and are_lists_equal(self.changes, other.changes)
 
+    def has_structural_changes(self):
+        """ Check if there are structural model changes present.
+
+        Returns:
+            :obj:`bool`: :obj:`True`, if structural model changes are present
+        """
+        for change in self.changes:
+            if isinstance(change, libsedml.SedAddXML) or \
+               isinstance(change, libsedml.SedChangeXML) or \
+               isinstance(change, libsedml.SedRemoveXML):
+                   return True
+        return False
 
 class ModelChange(SedBase, SedIdGroupMixin, TargetGroupMixin):
     """ A change to a model

--- a/biosimulators_utils/sedml/data_model.py
+++ b/biosimulators_utils/sedml/data_model.py
@@ -578,6 +578,7 @@ class Model(SedBase, SedIdGroupMixin):
         self.source = source
         self.language = language
         self.changes = changes or []
+        self.structural_changes = []
 
     def to_tuple(self):
         """ Get a tuple representation

--- a/biosimulators_utils/sedml/data_model.py
+++ b/biosimulators_utils/sedml/data_model.py
@@ -614,8 +614,9 @@ class Model(SedBase, SedIdGroupMixin):
             if isinstance(change, libsedml.SedAddXML) or \
                isinstance(change, libsedml.SedChangeXML) or \
                isinstance(change, libsedml.SedRemoveXML):
-                   return True
+                return True
         return False
+
 
 class ModelChange(SedBase, SedIdGroupMixin, TargetGroupMixin):
     """ A change to a model

--- a/biosimulators_utils/sedml/data_model.py
+++ b/biosimulators_utils/sedml/data_model.py
@@ -10,7 +10,6 @@ from ..biosimulations.data_model import Metadata  # noqa: F401
 from ..utils.core import are_lists_equal, none_sorted
 import abc
 import enum
-import libsedml
 
 
 __all__ = [
@@ -607,13 +606,15 @@ class Model(SedBase, SedIdGroupMixin):
     def has_structural_changes(self):
         """ Check if there are structural model changes present.
 
+        * Add element
+        * Replace element
+        * Remove element
+
         Returns:
             :obj:`bool`: :obj:`True`, if structural model changes are present
         """
         for change in self.changes:
-            if isinstance(change, libsedml.SedAddXML) or \
-               isinstance(change, libsedml.SedChangeXML) or \
-               isinstance(change, libsedml.SedRemoveXML):
+            if isinstance(change, (AddElementModelChange, ReplaceElementModelChange, RemoveElementModelChange)):
                 return True
         return False
 

--- a/biosimulators_utils/sedml/io.py
+++ b/biosimulators_utils/sedml/io.py
@@ -1372,10 +1372,6 @@ class SedmlSimulationReader(object):
                 change.target = change_sed.getTarget() or None
                 change.target_namespaces = self._get_namespaces_for_sed_object_targets(change_sed)
                 model.changes.append(change)
-                if isinstance(change_sed, libsedml.SedAddXML) or \
-                   isinstance(change_sed, libsedml.SedChangeXML) or \
-                   isinstance(change_sed, libsedml.SedRemoveXML):
-                       model.structural_changes.append(change)
 
         # data generators
         id_to_data_gen_map = {}

--- a/biosimulators_utils/sedml/io.py
+++ b/biosimulators_utils/sedml/io.py
@@ -1372,6 +1372,10 @@ class SedmlSimulationReader(object):
                 change.target = change_sed.getTarget() or None
                 change.target_namespaces = self._get_namespaces_for_sed_object_targets(change_sed)
                 model.changes.append(change)
+                if isinstance(change_sed, libsedml.SedAddXML) or \
+                   isinstance(change_sed, libsedml.SedChangeXML) or \
+                   isinstance(change_sed, libsedml.SedRemoveXML):
+                       model.structural_changes.append(change)
 
         # data generators
         id_to_data_gen_map = {}

--- a/biosimulators_utils/sedml/validation.py
+++ b/biosimulators_utils/sedml/validation.py
@@ -142,7 +142,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Model {} is invalid.'.format(style_id), style_errors])
 
             if style_warnings:
-                warnings.append(['Model {} may be invalid.'.format(style_id), style_warnings])
+                warnings.append(['Model {} generated warnings.'.format(style_id), style_warnings])
 
         # style bases are acyclic
         errors.extend(validate_base_style_network(doc.styles))
@@ -161,7 +161,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Model {} is invalid.'.format(model_id), model_errors])
 
             if model_warnings:
-                warnings.append(['Model {} may be invalid.'.format(model_id), model_warnings])
+                warnings.append(['Model {} generated warnings.'.format(model_id), model_warnings])
 
         # model sources are acyclic
         model_source_graph = networkx.DiGraph()
@@ -208,7 +208,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Simulation {} is invalid.'.format(sim_id), sim_errors])
             if sim_warnings:
                 sim_id = '`' + sim.id + '`' if sim and sim.id else str(i_sim + 1)
-                warnings.append(['Simulation {} may be invalid.'.format(sim_id), sim_warnings])
+                warnings.append(['Simulation {} generated warnings.'.format(sim_id), sim_warnings])
 
         # basic tasks reference a model and a simulation
         task_errors = {}
@@ -329,7 +329,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
 
                             if variable_warnings:
                                 variable_id = '`' + variable.id + '`' if variable and variable.id else str(i_variable + 1)
-                                range_warnings.append(['Variable {} may be invalid.'.format(variable_id), variable_warnings])
+                                range_warnings.append(['Variable {} generated warnings.'.format(variable_id), variable_warnings])
 
                         temp_errors, temp_warnings = validate_calculation(range)
                         range_errors.extend(temp_errors)
@@ -352,7 +352,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                     if range_warnings:
                         range_id = '`' + range.id + '`' if range and range.id else str(i_range + 1)
                         task_warnings[task]['ranges'].append(
-                            ['{} {} may be invalid.'.format(range.__class__.__name__, range_id), range_warnings])
+                            ['{} {} generated warnings.'.format(range.__class__.__name__, range_id), range_warnings])
 
         # ranges of repeated tasks have unique ids
         ranges_have_ids = True
@@ -515,7 +515,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
 
                         if variable_warnings:
                             variable_id = '`' + variable.id + '`' if variable and variable.id else str(i_variable + 1)
-                            change_warnings.append(['Variable {} may be invalid.'.format(variable_id), variable_warnings])
+                            change_warnings.append(['Variable {} generated warnings.'.format(variable_id), variable_warnings])
 
                     temp_errors, temp_warnings = validate_calculation(change)
                     change_errors.extend(temp_errors)
@@ -527,13 +527,13 @@ def validate_doc(doc, working_dir, validate_semantics=True,
 
                     if change_warnings:
                         change_id = '`' + change.id + '`' if change and change.id else str(i_change + 1)
-                        all_change_warnings.append(['Change {} may be invalid.'.format(change_id), change_warnings])
+                        all_change_warnings.append(['Change {} generated warnings.'.format(change_id), change_warnings])
 
                 if all_change_errors:
                     task_errors[task]['other'].append(['Changes are invalid.', all_change_errors])
 
                 if all_change_warnings:
-                    task_warnings[task]['other'].append(['Changes may be invalid.', all_change_warnings])
+                    task_warnings[task]['other'].append(['Changes generated warnings.', all_change_warnings])
 
         # repeated tasks involve 1 model
         if not subtasks_cyclic:
@@ -553,7 +553,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Task {} is invalid.'.format(task_id), task_errors[task]['other']])
 
             if task_warnings[task]['other']:
-                warnings.append(['Task {} may be invalid.'.format(task_id), task_warnings[task]['other']])
+                warnings.append(['Task {} generated warnings.'.format(task_id), task_warnings[task]['other']])
 
         # validate data generators
         if validate_targets_with_model_sources:
@@ -591,7 +591,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Data generator {} is invalid.'.format(data_gen_id), data_gen_errors])
 
             if data_gen_warnings:
-                warnings.append(['Data generator {} may be invalid.'.format(data_gen_id), data_gen_warnings])
+                warnings.append(['Data generator {} generated warnings.'.format(data_gen_id), data_gen_warnings])
 
         # validate outputs
         for i_output, output in enumerate(doc.outputs):
@@ -603,7 +603,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Output {} is invalid.'.format(output_id), output_errors])
 
             if output_warnings:
-                warnings.append(['Output {} may be invalid.'.format(output_id), output_warnings])
+                warnings.append(['Output {} generated warnings.'.format(output_id), output_warnings])
 
         # tasks, data generators that don't contribute to outputs
         used_data_generators = set()
@@ -886,7 +886,7 @@ def validate_model(model, model_ids, working_dir, validate_models_with_languages
     if model_change_errors:
         errors.append(['The changes of the model are invalid.', model_change_errors])
     if model_change_warnings:
-        warnings.append(['The changes of the model may be invalid.', model_change_warnings])
+        warnings.append(['The changes of the model generated warnings.', model_change_warnings])
 
     return (errors, warnings)
 
@@ -975,7 +975,7 @@ def validate_model_source(model, model_ids, working_dir, validate_models_with_la
             if model_source_errors:
                 errors.append(['The model file `{}` is invalid.'.format(model.source), model_source_errors])
             if model_source_warnings:
-                warnings.append(['The model file `{}` may be invalid.'.format(model.source), model_source_warnings])
+                warnings.append(['The model file `{}` generated warnings.'.format(model.source), model_source_warnings])
 
     return (errors, warnings)
 
@@ -1068,6 +1068,8 @@ def validate_model_changes(model):
     errors = []
     warnings = []
 
+    if len(model.changes)>0:
+        warnings.append(["Model change XPaths are currently not validated."])
     for i_change, change in enumerate(model.changes):
         change_errors = []
         change_warnings = []
@@ -1078,7 +1080,8 @@ def validate_model_changes(model):
                                                              ModelChange, model.language, model.id,
                                                              check_in_model_source=False)
                 change_errors.extend(temp_errors)
-                change_warnings.extend(temp_warnings)
+                # Setting check_in_model_source to False means that we don't even try to validate XPaths
+                # change_warnings.extend(temp_warnings)
 
         else:
             change_errors.append(['Model attribute change must define a target.'])
@@ -1119,7 +1122,7 @@ def validate_model_changes(model):
 
                 if variable_warnings:
                     var_id = '`' + variable.id + '`' if variable and variable.id else str(i_variable + 1)
-                    change_warnings.append(['Variable {} may be invalid.'.format(var_id), variable_warnings])
+                    change_warnings.append(['Variable {} generated warnings.'.format(var_id), variable_warnings])
 
             temp_errors, temp_warnings = validate_calculation(change)
             change_errors.extend(temp_errors)
@@ -1131,7 +1134,7 @@ def validate_model_changes(model):
 
         if change_warnings:
             change_id = '`' + change.id + '`' if change and change.id else str(i_change + 1)
-            warnings.append(['Change {} may be invalid.'.format(change_id), change_warnings])
+            warnings.append(['Change {} generated warnings.'.format(change_id), change_warnings])
 
     return errors, warnings
 
@@ -1371,8 +1374,7 @@ def validate_data_generator_variables(variables, model_etrees=None, validate_tar
             models = get_models_referenced_by_task(variable.task)
             for model in models:
                 if model and model.language:
-                    model_changes = model.changes or list(filter(lambda change: change.model == model,
-                                                                 get_model_changes_for_task(variable.task)))
+                    model_changes = model.structural_changes
 
                     temp_errors, temp_warnings = validate_target(
                         variable.target, variable.target_namespaces,
@@ -1389,7 +1391,7 @@ def validate_data_generator_variables(variables, model_etrees=None, validate_tar
 
         if variable_warnings:
             variable_id = '`' + variable.id + '`' if variable and variable.id else str(i_variable + 1)
-            warnings.append(['Variable {} may be invalid.'.format(variable_id), variable_warnings])
+            warnings.append(['Variable {} generated warnings.'.format(variable_id), variable_warnings])
 
     if len(task_types) > 1:
         warnings.append(['The variables do not have consistent shapes.'])
@@ -1505,7 +1507,7 @@ def validate_output(output):
                 errors.append(['Curve {} is invalid.'.format(curve_id), curve_errors])
             if curve_warnings:
                 curve_id = '`' + curve.id + '`' if curve and curve.id else str(i_curve + 1)
-                warnings.append(['Curve {} may be invalid.'.format(curve_id), curve_warnings])
+                warnings.append(['Curve {} generated warnings.'.format(curve_id), curve_warnings])
 
         if len(x_scales) > 1:
             warnings.append(['Curves do not have consistent x-scales.'])
@@ -1566,7 +1568,7 @@ def validate_output(output):
                 errors.append(['Surface {} is invalid.'.format(surface_id), surface_errors])
             if surface_warnings:
                 surface_id = '`' + surface.id + '`' if surface and surface.id else str(i_surface + 1)
-                warnings.append(['Surface {} may be invalid.'.format(surface_id), surface_warnings])
+                warnings.append(['Surface {} generated warnings.'.format(surface_id), surface_warnings])
 
         if len(x_scales) > 1:
             warnings.append(['Surfaces do not have consistent x-scales.'])

--- a/biosimulators_utils/sedml/validation.py
+++ b/biosimulators_utils/sedml/validation.py
@@ -1374,14 +1374,12 @@ def validate_data_generator_variables(variables, model_etrees=None, validate_tar
             models = get_models_referenced_by_task(variable.task)
             for model in models:
                 if model and model.language:
-                    model_changes = model.structural_changes
-
                     temp_errors, temp_warnings = validate_target(
                         variable.target, variable.target_namespaces,
                         DataGenerator, model.language,
                         model_id=model.id,
                         model_etree=model_etrees.get(model, None),
-                        check_in_model_source=not model_changes and validate_targets_with_model_sources)
+                        check_in_model_source=not model.has_structural_changes() and validate_targets_with_model_sources)
                     variable_errors.extend(temp_errors)
                     variable_warnings.extend(temp_warnings)
 

--- a/biosimulators_utils/sedml/validation.py
+++ b/biosimulators_utils/sedml/validation.py
@@ -142,7 +142,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Model {} is invalid.'.format(style_id), style_errors])
 
             if style_warnings:
-                warnings.append(['Model {} generated warnings.'.format(style_id), style_warnings])
+                warnings.append(['Model {} has warnings.'.format(style_id), style_warnings])
 
         # style bases are acyclic
         errors.extend(validate_base_style_network(doc.styles))
@@ -161,7 +161,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Model {} is invalid.'.format(model_id), model_errors])
 
             if model_warnings:
-                warnings.append(['Model {} generated warnings.'.format(model_id), model_warnings])
+                warnings.append(['Model {} has warnings.'.format(model_id), model_warnings])
 
         # model sources are acyclic
         model_source_graph = networkx.DiGraph()
@@ -208,7 +208,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Simulation {} is invalid.'.format(sim_id), sim_errors])
             if sim_warnings:
                 sim_id = '`' + sim.id + '`' if sim and sim.id else str(i_sim + 1)
-                warnings.append(['Simulation {} generated warnings.'.format(sim_id), sim_warnings])
+                warnings.append(['Simulation {} has warnings.'.format(sim_id), sim_warnings])
 
         # basic tasks reference a model and a simulation
         task_errors = {}
@@ -329,7 +329,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
 
                             if variable_warnings:
                                 variable_id = '`' + variable.id + '`' if variable and variable.id else str(i_variable + 1)
-                                range_warnings.append(['Variable {} generated warnings.'.format(variable_id), variable_warnings])
+                                range_warnings.append(['Variable {} has warnings.'.format(variable_id), variable_warnings])
 
                         temp_errors, temp_warnings = validate_calculation(range)
                         range_errors.extend(temp_errors)
@@ -352,7 +352,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                     if range_warnings:
                         range_id = '`' + range.id + '`' if range and range.id else str(i_range + 1)
                         task_warnings[task]['ranges'].append(
-                            ['{} {} generated warnings.'.format(range.__class__.__name__, range_id), range_warnings])
+                            ['{} {} has warnings.'.format(range.__class__.__name__, range_id), range_warnings])
 
         # ranges of repeated tasks have unique ids
         ranges_have_ids = True
@@ -515,7 +515,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
 
                         if variable_warnings:
                             variable_id = '`' + variable.id + '`' if variable and variable.id else str(i_variable + 1)
-                            change_warnings.append(['Variable {} generated warnings.'.format(variable_id), variable_warnings])
+                            change_warnings.append(['Variable {} has warnings.'.format(variable_id), variable_warnings])
 
                     temp_errors, temp_warnings = validate_calculation(change)
                     change_errors.extend(temp_errors)
@@ -527,13 +527,13 @@ def validate_doc(doc, working_dir, validate_semantics=True,
 
                     if change_warnings:
                         change_id = '`' + change.id + '`' if change and change.id else str(i_change + 1)
-                        all_change_warnings.append(['Change {} generated warnings.'.format(change_id), change_warnings])
+                        all_change_warnings.append(['Change {} has warnings.'.format(change_id), change_warnings])
 
                 if all_change_errors:
                     task_errors[task]['other'].append(['Changes are invalid.', all_change_errors])
 
                 if all_change_warnings:
-                    task_warnings[task]['other'].append(['Changes generated warnings.', all_change_warnings])
+                    task_warnings[task]['other'].append(['Changes has warnings.', all_change_warnings])
 
         # repeated tasks involve 1 model
         if not subtasks_cyclic:
@@ -553,7 +553,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Task {} is invalid.'.format(task_id), task_errors[task]['other']])
 
             if task_warnings[task]['other']:
-                warnings.append(['Task {} generated warnings.'.format(task_id), task_warnings[task]['other']])
+                warnings.append(['Task {} has warnings.'.format(task_id), task_warnings[task]['other']])
 
         # validate data generators
         if validate_targets_with_model_sources:
@@ -591,7 +591,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Data generator {} is invalid.'.format(data_gen_id), data_gen_errors])
 
             if data_gen_warnings:
-                warnings.append(['Data generator {} generated warnings.'.format(data_gen_id), data_gen_warnings])
+                warnings.append(['Data generator {} has warnings.'.format(data_gen_id), data_gen_warnings])
 
         # validate outputs
         for i_output, output in enumerate(doc.outputs):
@@ -603,7 +603,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                 errors.append(['Output {} is invalid.'.format(output_id), output_errors])
 
             if output_warnings:
-                warnings.append(['Output {} generated warnings.'.format(output_id), output_warnings])
+                warnings.append(['Output {} has warnings.'.format(output_id), output_warnings])
 
         # tasks, data generators that don't contribute to outputs
         used_data_generators = set()
@@ -886,7 +886,7 @@ def validate_model(model, model_ids, working_dir, validate_models_with_languages
     if model_change_errors:
         errors.append(['The changes of the model are invalid.', model_change_errors])
     if model_change_warnings:
-        warnings.append(['The changes of the model generated warnings.', model_change_warnings])
+        warnings.append(['The changes of the model has warnings.', model_change_warnings])
 
     return (errors, warnings)
 
@@ -975,7 +975,7 @@ def validate_model_source(model, model_ids, working_dir, validate_models_with_la
             if model_source_errors:
                 errors.append(['The model file `{}` is invalid.'.format(model.source), model_source_errors])
             if model_source_warnings:
-                warnings.append(['The model file `{}` generated warnings.'.format(model.source), model_source_warnings])
+                warnings.append(['The model file `{}` has warnings.'.format(model.source), model_source_warnings])
 
     return (errors, warnings)
 
@@ -1068,8 +1068,9 @@ def validate_model_changes(model):
     errors = []
     warnings = []
 
-    if len(model.changes) > 0:
-        warnings.append(["Model change XPaths are currently not validated."])
+    if model.language and does_model_language_use_xpath_variable_targets(model.language) and len(model.changes) > 0:
+        warnings.append(["Model change XPaths cannot be validated separate from their execution."])
+
     for i_change, change in enumerate(model.changes):
         change_errors = []
         change_warnings = []
@@ -1078,10 +1079,10 @@ def validate_model_changes(model):
             if model.language:
                 temp_errors, temp_warnings = validate_target(change.target, change.target_namespaces,
                                                              ModelChange, model.language, model.id,
-                                                             check_in_model_source=False)
+                                                             check_in_model_source=False,
+                                                             warn_xpaths_not_validated=False)
                 change_errors.extend(temp_errors)
-                # Setting check_in_model_source to False means that we don't even try to validate XPaths
-                # change_warnings.extend(temp_warnings)
+                change_warnings.extend(temp_warnings)
 
         else:
             change_errors.append(['Model attribute change must define a target.'])
@@ -1122,7 +1123,7 @@ def validate_model_changes(model):
 
                 if variable_warnings:
                     var_id = '`' + variable.id + '`' if variable and variable.id else str(i_variable + 1)
-                    change_warnings.append(['Variable {} generated warnings.'.format(var_id), variable_warnings])
+                    change_warnings.append(['Variable {} has warnings.'.format(var_id), variable_warnings])
 
             temp_errors, temp_warnings = validate_calculation(change)
             change_errors.extend(temp_errors)
@@ -1134,7 +1135,7 @@ def validate_model_changes(model):
 
         if change_warnings:
             change_id = '`' + change.id + '`' if change and change.id else str(i_change + 1)
-            warnings.append(['Change {} generated warnings.'.format(change_id), change_warnings])
+            warnings.append(['Change {} has warnings.'.format(change_id), change_warnings])
 
     return errors, warnings
 
@@ -1374,12 +1375,14 @@ def validate_data_generator_variables(variables, model_etrees=None, validate_tar
             models = get_models_referenced_by_task(variable.task)
             for model in models:
                 if model and model.language:
+                    model_changes = model.changes or list(filter(lambda change: change.model == model,
+                                                                 get_model_changes_for_task(variable.task)))
                     temp_errors, temp_warnings = validate_target(
                         variable.target, variable.target_namespaces,
                         DataGenerator, model.language,
                         model_id=model.id,
                         model_etree=model_etrees.get(model, None),
-                        check_in_model_source=not model.has_structural_changes() and validate_targets_with_model_sources)
+                        check_in_model_source=not model_changes and validate_targets_with_model_sources)
                     variable_errors.extend(temp_errors)
                     variable_warnings.extend(temp_warnings)
 
@@ -1389,7 +1392,7 @@ def validate_data_generator_variables(variables, model_etrees=None, validate_tar
 
         if variable_warnings:
             variable_id = '`' + variable.id + '`' if variable and variable.id else str(i_variable + 1)
-            warnings.append(['Variable {} generated warnings.'.format(variable_id), variable_warnings])
+            warnings.append(['Variable {} has warnings.'.format(variable_id), variable_warnings])
 
     if len(task_types) > 1:
         warnings.append(['The variables do not have consistent shapes.'])
@@ -1505,7 +1508,7 @@ def validate_output(output):
                 errors.append(['Curve {} is invalid.'.format(curve_id), curve_errors])
             if curve_warnings:
                 curve_id = '`' + curve.id + '`' if curve and curve.id else str(i_curve + 1)
-                warnings.append(['Curve {} generated warnings.'.format(curve_id), curve_warnings])
+                warnings.append(['Curve {} has warnings.'.format(curve_id), curve_warnings])
 
         if len(x_scales) > 1:
             warnings.append(['Curves do not have consistent x-scales.'])
@@ -1566,7 +1569,7 @@ def validate_output(output):
                 errors.append(['Surface {} is invalid.'.format(surface_id), surface_errors])
             if surface_warnings:
                 surface_id = '`' + surface.id + '`' if surface and surface.id else str(i_surface + 1)
-                warnings.append(['Surface {} generated warnings.'.format(surface_id), surface_warnings])
+                warnings.append(['Surface {} has warnings.'.format(surface_id), surface_warnings])
 
         if len(x_scales) > 1:
             warnings.append(['Surfaces do not have consistent x-scales.'])
@@ -1590,7 +1593,8 @@ def validate_output(output):
     return (errors, warnings)
 
 
-def validate_target(target, namespaces, context, language, model_id, model_etree=None, doc=None, check_in_model_source=False):
+def validate_target(target, namespaces, context, language, model_id, model_etree=None, doc=None, check_in_model_source=False,
+                    warn_xpaths_not_validated=True):
     """ Validate that a target is a valid XPath and that the namespaces needed to resolve a target are defined
 
     Args:
@@ -1602,6 +1606,7 @@ def validate_target(target, namespaces, context, language, model_id, model_etree
         model_etree (:obj:`etree.Element`, optional): XML element tree for model source
         doc (:obj:`SedDocument`, optional): SED document
         check_in_model_source (:obj:`bool`, optional): whether to check that the target exists in the source
+        warn_xpaths_not_validated (:obj:`bool`, optional): whether to warn that XPaths cannot be validated
 
     Returns:
         nested :obj:`list` of :obj:`str`: nested list of errors (e.g., required ids missing or ids not unique)
@@ -1651,7 +1656,8 @@ def validate_target(target, namespaces, context, language, model_id, model_etree
                         errors.append(['XPath `{}` matches multiple elements of model `{}`.'.format(xpath, model_id or '')])
 
                 else:
-                    warnings.append(['XPath could not be validated.'])
+                    if warn_xpaths_not_validated:
+                        warnings.append(['XPath could not be validated.'])
 
             except lxml.etree.XPathEvalError as exception:
                 if 'Undefined namespace prefix' in str(exception):

--- a/biosimulators_utils/sedml/validation.py
+++ b/biosimulators_utils/sedml/validation.py
@@ -1068,7 +1068,7 @@ def validate_model_changes(model):
     errors = []
     warnings = []
 
-    if len(model.changes)>0:
+    if len(model.changes) > 0:
         warnings.append(["Model change XPaths are currently not validated."])
     for i_change, change in enumerate(model.changes):
         change_errors = []

--- a/tests/combine/test_combine_validation.py
+++ b/tests/combine/test_combine_validation.py
@@ -221,7 +221,7 @@ class ValidationTestCase(unittest.TestCase):
             errors, warnings = validate(archive, self.tmp_dir)
         self.assertEqual(errors, [])
         self.assertEqual(len(warnings), 1)
-        self.assertIn('may be invalid', flatten_nested_list_of_strings(warnings))
+        self.assertIn('has warnings', flatten_nested_list_of_strings(warnings))
         self.assertIn('my warning', flatten_nested_list_of_strings(warnings))
 
     def test_manifest_in_manifest(self):

--- a/tests/sedml/test_sedml_data_model.py
+++ b/tests/sedml/test_sedml_data_model.py
@@ -400,3 +400,22 @@ class DataModelTestCase(unittest.TestCase):
         self.assertEqual(range.number_of_steps, 20)
         range.number_of_steps = 30
         self.assertEqual(range.number_of_points, 30)
+
+    def test_Model_has_structural_changes(self):
+        model = data_model.Model()
+        self.assertFalse(model.has_structural_changes())
+
+        model.changes.append(data_model.ModelAttributeChange())
+        self.assertFalse(model.has_structural_changes())
+
+        model.changes.append(data_model.AddElementModelChange())
+        self.assertTrue(model.has_structural_changes())
+
+        model.changes = [data_model.ReplaceElementModelChange()]
+        self.assertTrue(model.has_structural_changes())
+
+        model.changes = [data_model.RemoveElementModelChange()]
+        self.assertTrue(model.has_structural_changes())
+
+        model.changes = [data_model.ComputeModelChange()]
+        self.assertFalse(model.has_structural_changes())

--- a/tests/sedml/test_sedml_validation.py
+++ b/tests/sedml/test_sedml_validation.py
@@ -319,7 +319,7 @@ class ValidationTestCase(unittest.TestCase):
         doc.models[0].changes[0].variables[0].target = None
         errors, warnings = validation.validate_doc(doc, self.dirname)
         self.assertIn('must define a target', flatten_nested_list_of_strings(errors))
-        self.assertIn('XPath could not be validated.', flatten_nested_list_of_strings(warnings))
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
 
         doc.models[0].changes[0].variables[0].target = 'y'
         doc.models[0].changes[0].variables[0].symbol = 'y'
@@ -331,7 +331,7 @@ class ValidationTestCase(unittest.TestCase):
         doc.models[0].changes[0].variables[0].model = None
         errors, warnings = validation.validate_doc(doc, self.dirname)
         self.assertIn('must reference a model', flatten_nested_list_of_strings(errors))
-        self.assertIn('XPath could not be validated.', flatten_nested_list_of_strings(warnings))
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
 
         doc.models[0].changes[0].variables[0].model = doc.models[0]
         doc.models[0].changes[0].variables[0].task = data_model.Task(
@@ -958,23 +958,23 @@ class ValidationTestCase(unittest.TestCase):
         )
         errors, warnings = validation.validate_model_changes(model)
         self.assertIn('not supported', flatten_nested_list_of_strings(errors))
-        self.assertIn('XPath could not be validated.', flatten_nested_list_of_strings(warnings))
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
 
         model.changes[0].variables[0].target = model.changes[0].target
         model.changes[0].variables[0].target_namespaces = model.changes[0].target_namespaces
         errors, warnings = validation.validate_model_changes(model)
         self.assertEqual(errors, [])
-        self.assertIn('XPath could not be validated.', flatten_nested_list_of_strings(warnings))
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
 
         with mock.patch('biosimulators_utils.sedml.validation.validate_target', return_value=([], [['warning']])):
             errors, warnings = validation.validate_model_changes(model)
         self.assertEqual(errors, [])
-        self.assertIn('may be invalid', flatten_nested_list_of_strings(warnings))
+        self.assertIn('has warnings', flatten_nested_list_of_strings(warnings))
 
         with mock.patch('biosimulators_utils.sedml.validation.validate_target', return_value=([], [['warning']])):
             errors, warnings = validation.validate_model(model, [], os.path.dirname(__file__))
         self.assertEqual(errors, [])
-        self.assertIn('changes of the model may be invalid', flatten_nested_list_of_strings(warnings))
+        self.assertIn('changes of the model has warnings', flatten_nested_list_of_strings(warnings))
 
     def test_validate_simulation(self):
         sim = data_model.UniformTimeCourseSimulation(
@@ -1109,12 +1109,12 @@ class ValidationTestCase(unittest.TestCase):
 
         errors, warnings = self._validate_task(task, variables)
         self.assertIn('is not supported', flatten_nested_list_of_strings(errors))
-        self.assertEqual(warnings, [])
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
         task.model.changes = [data_model.ModelAttributeChange()]
 
         errors, warnings = self._validate_task(task, variables)
         self.assertIn('must define a target', flatten_nested_list_of_strings(errors))
-        self.assertEqual(warnings, [])
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
         task.model.changes = [
             data_model.ComputeModelChange(
                 target='x',
@@ -1136,7 +1136,7 @@ class ValidationTestCase(unittest.TestCase):
 
         errors, warnings = self._validate_task(task, variables)
         self.assertIn('must define a target', flatten_nested_list_of_strings(errors))
-        self.assertIn('XPath could not be validated', flatten_nested_list_of_strings(warnings))
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
         task.model.changes = [
             data_model.ComputeModelChange(
                 target='x',
@@ -1147,7 +1147,7 @@ class ValidationTestCase(unittest.TestCase):
 
         errors, warnings = self._validate_task(task, variables)
         self.assertIn('must reference a model', flatten_nested_list_of_strings(errors))
-        self.assertIn('XPath could not be validated', flatten_nested_list_of_strings(warnings))
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
         task.model.changes = [
             data_model.ComputeModelChange(
                 target='x',
@@ -1158,7 +1158,7 @@ class ValidationTestCase(unittest.TestCase):
 
         errors, warnings = self._validate_task(task, variables)
         self.assertIn('should not reference a task', flatten_nested_list_of_strings(errors))
-        self.assertIn('XPath could not be validated', flatten_nested_list_of_strings(warnings))
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
         task.model.changes = [
             data_model.ComputeModelChange(
                 target='x',
@@ -1169,7 +1169,7 @@ class ValidationTestCase(unittest.TestCase):
 
         errors, warnings = self._validate_task(task, variables)
         self.assertIn('must have an id', flatten_nested_list_of_strings(errors))
-        self.assertIn('XPath could not be validated', flatten_nested_list_of_strings(warnings))
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
         task.model.changes = [
             data_model.ComputeModelChange(
                 target='x',
@@ -1180,7 +1180,7 @@ class ValidationTestCase(unittest.TestCase):
 
         errors, warnings = self._validate_task(task, variables)
         self.assertIn('must have an id', flatten_nested_list_of_strings(errors))
-        self.assertIn('XPath could not be validated', flatten_nested_list_of_strings(warnings))
+        self.assertIn('Model change XPaths cannot be validated', flatten_nested_list_of_strings(warnings))
         task.model.changes = []
 
         errors, warnings = self._validate_task(task, variables)


### PR DESCRIPTION
This is not a general fix for consolidating warnings, but consolidates two sets of warnings, and fixes a third.

* The SBML warnings are now consolidated by error number.
* The ModelChange 'cannot validate XPath' messages are now simply "Model change XPaths are currently not validated."  This is because the code does not even attempt to validate ModelChange XPaths.
* The DataGenerator code now checks to make sure that there aren't *structural* ModelChanges in the referenced model instead of checking to see if there are *any* ModelChanges.  ModelChanges that change attributes or are of type ComputeChange will not invalidate any other XPath in the SED-ML, unlike the AddXML, ReplaceXML, and RemoveXML changes.  Fortunately, the latter are rare to nonexistent.

...except that I now realize as I type this that a ChangeAttribute could change the ID of an element, making an XPath that relied on that attribute invalid.  But honestly, if you do that, and biosimulators_utils tells you that you have an invalid XPath, I think you deserve it.  I can't see it actually happening in the wild.

However, I do see the danger, and perhaps the goal eventually was to *apply* the ModelChanges before validating XPaths.  Maybe we can keep this approach until that day?

The fix could also be applied to the ModelChange XPath validation:  check to ensure that no structural changes were present, and if not, attempt to validate the XPaths.

The final change is that I changed the text 'could be invalid' to 'generated warnings', because the former seems a little hyperbolic, and many warnings *cannot* make the file invalid; they indicate something else might be wrong.  I feel like the user should be able to peruse the warnings as they are and decide for themselves whether the warnings indicate there might be something invalid present.  (This is particularly true for SBML:  *No* warning indicates that the file may be invalid.  All invalid models are caught with errors, not warnings.  If you prefer the 'may be invalid' wording in general, I request that you leave it for SBML, at least.)

The design of collecting warnings by type could be also applied to errors, but errors are more serious, and always need to all be fixed.  The specific messages indicating where each error comes from I feel are worth the extra potential wordiness of some design error resulting in walls of text.

Fixes #96.