### PR TITLE
Fixes the temp-biomodels github actions failure.

### DIFF
--- a/biosimulators_utils/omex_meta/utils.py
+++ b/biosimulators_utils/omex_meta/utils.py
@@ -51,12 +51,16 @@ def build_omex_meta_file_for_model(model_filename,
         raise ValueError('Metadata could not be extracted from model `{}`:\n  {}'.format(
             model_filename, '\n'.join(errors).replace('\n', '\n  ')))
 
-    model = editor.get_xml()
+    model = None
+    try:
+        model = editor.get_xml()
+    except:
+        pass
     if not model:
         errors = ''.join([logger[i_message].get_message() for i_message in range(len(logger))])
         raise RuntimeError('Model `{}` could not be read:\n  {}'.format(
             model_filename, errors.replace('\n', '\n  ')))
-    with open(model_filename, 'w') as file:
+    with open(model_filename, 'w', encoding="utf-8") as file:
         file.write(model)
 
     if rdf.to_file(metadata_filename, metadata_format.value) != 0:

--- a/biosimulators_utils/omex_meta/utils.py
+++ b/biosimulators_utils/omex_meta/utils.py
@@ -9,13 +9,16 @@
 from .data_model import OmexMetadataOutputFormat
 import os
 import pyomexmeta
+import subprocess
+import sys
 
 __all__ = ['build_omex_meta_file_for_model', 'get_local_combine_archive_content_uri', 'get_global_combine_archive_content_uri']
 
 
 def build_omex_meta_file_for_model(model_filename,
                                    metadata_filename,
-                                   metadata_format=OmexMetadataOutputFormat.rdfxml_abbrev):
+                                   metadata_format=OmexMetadataOutputFormat.rdfxml_abbrev,
+                                   encoding='utf-8'):
     """ Create an OMEX metadata file for a model encoded in CellML or SBML. Also
     add missing metadata ids to the model file.
 
@@ -23,8 +26,9 @@ def build_omex_meta_file_for_model(model_filename,
         model_filename (:obj:`str`): path to model to extract metadata about
         metadata_filename (:obj:`str`): path to save metadata
         metadata_format (:obj:`OmexMetadataOutputFormat`, optional): format for :obj:`metadata_filename`
+        encoding (:obj:`str`, optional): encoding (e.g., ``utf-8``)
     """
-    # uses subprocess by pyomexmetadata has no error handling
+    # uses subprocess because pyomexmeta has insufficient error handling
     if not isinstance(model_filename, str) or not os.path.isfile(model_filename):
         raise FileNotFoundError('`{}` is not a file.'.format(model_filename))
 
@@ -34,6 +38,57 @@ def build_omex_meta_file_for_model(model_filename,
     if not isinstance(metadata_format, OmexMetadataOutputFormat):
         raise NotImplementedError('Output format `{}` is not supported.'.format(metadata_format))
 
+    # TODO: uncomment and delete below once pyomexmeta has better error handling
+    # _build_omex_meta_file_for_model(model_filename, metadata_filename, metadata_format.value, encoding)
+
+    process = subprocess.run(
+        [
+            sys.executable, '-c',
+            'from {} import {}; {}("{}", "{}", "{}", "{}")'.format(
+                _build_omex_meta_file_for_model_error_wrapper.__module__,
+                _build_omex_meta_file_for_model_error_wrapper.__name__,
+                _build_omex_meta_file_for_model_error_wrapper.__name__,
+                model_filename.replace('"', '\\"'),
+                metadata_filename.replace('"', '\\"'),
+                metadata_format.value.replace('"', '\\"'),
+                encoding.replace('"', '\\"'),
+            )
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True)
+    if process.returncode != 0:
+        raise RuntimeError(process.stderr or 'Model `{}` could not be read'.format(model_filename))
+
+
+def _build_omex_meta_file_for_model_error_wrapper(model_filename, metadata_filename,
+                                                  metadata_format=OmexMetadataOutputFormat.rdfxml_abbrev.value, encoding='utf-8'):
+    """ Wrapper for ``_build_omex_meta_file_for_model``
+
+    Args:
+        model_filename (:obj:`str`): path to model to extract metadata about
+        metadata_filename (:obj:`str`): path to save metadata
+        metadata_format (:obj:`str`, optional): format for :obj:`metadata_filename`
+        encoding (:obj:`str`, optional): encoding (e.g., ``utf-8``)
+    """
+    try:
+        _build_omex_meta_file_for_model(model_filename, metadata_filename, metadata_format, encoding)
+    except (ValueError, RuntimeError) as exception:
+        raise SystemExit(str(exception))
+
+
+def _build_omex_meta_file_for_model(model_filename, metadata_filename,
+                                    metadata_format=OmexMetadataOutputFormat.rdfxml_abbrev.value, encoding='utf-8'):
+    """ Create an OMEX metadata file for a model encoded in CellML or SBML. Also
+    add missing metadata ids to the model file.
+
+    Args:
+        model_filename (:obj:`str`): path to model to extract metadata about
+        metadata_filename (:obj:`str`): path to save metadata
+        metadata_format (:obj:`str`, optional): format for :obj:`metadata_filename`
+        encoding (:obj:`str`, optional): encoding (e.g., ``utf-8``)
+    """
+    metadata_format = OmexMetadataOutputFormat(metadata_format)
     rdf = pyomexmeta.RDF()
 
     pyomexmeta_log_level = pyomexmeta.Logger.get_level()
@@ -46,24 +101,24 @@ def build_omex_meta_file_for_model(model_filename,
 
     logger = pyomexmeta.Logger()
 
-    errors = ''.join([logger[i_message].get_message() for i_message in range(len(logger))])
+    errors = [logger[i_message].get_message() for i_message in range(len(logger))]
     if errors:
         raise ValueError('Metadata could not be extracted from model `{}`:\n  {}'.format(
             model_filename, '\n'.join(errors).replace('\n', '\n  ')))
 
     try:
         model = editor.get_xml()
-    except Exception as e:
-        raise RuntimeError('Model `{}` could not be read: '.format(model_filename) + str(e) )
+    except Exception as exception:
+        raise ValueError('Model `{}` could not be read'.format(model_filename)) from exception
     if not model:
-        errors = ''.join([logger[i_message].get_message() for i_message in range(len(logger))])
-        raise RuntimeError('Model `{}` could not be read:\n  {}'.format(
+        errors = [logger[i_message].get_message() for i_message in range(len(logger))]
+        raise ValueError('Model `{}` could not be read:\n  {}'.format(
             model_filename, errors.replace('\n', '\n  ')))
-    with open(model_filename, 'w', encoding="utf-8") as file:
+    with open(model_filename, 'w', encoding=encoding) as file:
         file.write(model)
 
     if rdf.to_file(metadata_filename, metadata_format.value) != 0:
-        errors = ''.join([logger[i_message].get_message() for i_message in range(len(logger))])
+        errors = [logger[i_message].get_message() for i_message in range(len(logger))]
         raise RuntimeError('OMEX metadata could not be saved to `{}` in `{}` format:\n  {}'.format(
             metadata_filename, metadata_format.value, errors.replace('\n', '\n  ')))
 

--- a/biosimulators_utils/omex_meta/utils.py
+++ b/biosimulators_utils/omex_meta/utils.py
@@ -51,11 +51,10 @@ def build_omex_meta_file_for_model(model_filename,
         raise ValueError('Metadata could not be extracted from model `{}`:\n  {}'.format(
             model_filename, '\n'.join(errors).replace('\n', '\n  ')))
 
-    model = None
     try:
         model = editor.get_xml()
-    except:
-        pass
+    except Exception as e:
+        raise RuntimeError('Model `{}` could not be read: '.format(model_filename) + str(e) )
     if not model:
         errors = ''.join([logger[i_message].get_message() for i_message in range(len(logger))])
         raise RuntimeError('Model `{}` could not be read:\n  {}'.format(

--- a/tests/omex_meta/test_omex_meta_utils.py
+++ b/tests/omex_meta/test_omex_meta_utils.py
@@ -1,6 +1,7 @@
 from biosimulators_utils.omex_meta.data_model import OmexMetadataOutputFormat
 from biosimulators_utils.omex_meta.utils import (
-    build_omex_meta_file_for_model, get_local_combine_archive_content_uri, get_global_combine_archive_content_uri)
+    build_omex_meta_file_for_model, _build_omex_meta_file_for_model, _build_omex_meta_file_for_model_error_wrapper,
+    get_local_combine_archive_content_uri, get_global_combine_archive_content_uri)
 import os
 import shutil
 import tempfile
@@ -42,12 +43,65 @@ class OmexMetaUtilsTestCase(unittest.TestCase):
         with self.assertRaisesRegex(NotImplementedError, 'is not supported'):
             build_omex_meta_file_for_model(model_filename, metadata_filename, metadata_format)
 
+    def test__build_omex_meta_file_for_model_error_handling(self):
         model_filename = os.path.join(self.temp_dirname, 'model.xml')
         metadata_filename = os.path.join(self.temp_dirname, 'metadata.rdf')
         metadata_format = OmexMetadataOutputFormat.rdfxml_abbrev
         with open(model_filename, 'w') as file:
             file.write('<sbml></sbml')
         with self.assertRaisesRegex(ValueError, 'could not be extracted'):
+            _build_omex_meta_file_for_model(model_filename, metadata_filename, metadata_format.value)
+
+        # model_filename = os.path.join(self.temp_dirname, 'model.xml')
+        # metadata_filename = os.path.join(self.temp_dirname, 'metadata.rdf')
+        # metadata_format = OmexMetadataOutputFormat.rdfxml_abbrev
+        # with open(model_filename, 'w') as file:
+        #     file.write('<sbml></sbml>')
+        # with self.assertRaisesRegex(ValueError, 'could not be read'):
+        #    _build_omex_meta_file_for_model(model_filename, metadata_filename, metadata_format.value)
+
+        model_filename = os.path.join(self.FIXTURE_DIRNAME, 'omex-metadata', 'simple-regulation.xml')
+        metadata_filename = os.path.join(self.temp_dirname, 'metadata.rdf')
+        metadata_format = OmexMetadataOutputFormat.rdfxml_abbrev
+        _build_omex_meta_file_for_model(model_filename, metadata_filename, metadata_format.value)
+
+    def test__build_omex_meta_file_for_model_error_handling_wrapper(self):
+        model_filename = os.path.join(self.temp_dirname, 'model.xml')
+        metadata_filename = os.path.join(self.temp_dirname, 'metadata.rdf')
+        metadata_format = OmexMetadataOutputFormat.rdfxml_abbrev
+        with open(model_filename, 'w') as file:
+            file.write('<sbml></sbml')
+        with self.assertRaisesRegex(SystemExit, 'could not be extracted'):
+            _build_omex_meta_file_for_model_error_wrapper(model_filename, metadata_filename, metadata_format.value)
+
+        # model_filename = os.path.join(self.temp_dirname, 'model.xml')
+        # metadata_filename = os.path.join(self.temp_dirname, 'metadata.rdf')
+        # metadata_format = OmexMetadataOutputFormat.rdfxml_abbrev
+        # with open(model_filename, 'w') as file:
+        #     file.write('<sbml></sbml>')
+        # with self.assertRaisesRegex(SystemExit, 'could not be read'):
+        #     _build_omex_meta_file_for_model_error_wrapper(model_filename, metadata_filename, metadata_format.value)
+
+        model_filename = os.path.join(self.FIXTURE_DIRNAME, 'omex-metadata', 'simple-regulation.xml')
+        metadata_filename = os.path.join(self.temp_dirname, 'metadata.rdf')
+        metadata_format = OmexMetadataOutputFormat.rdfxml_abbrev
+        _build_omex_meta_file_for_model_error_wrapper(model_filename, metadata_filename, metadata_format.value)
+
+    def test__build_omex_meta_file_for_model_error_handling_subprocess(self):
+        model_filename = os.path.join(self.temp_dirname, 'model.xml')
+        metadata_filename = os.path.join(self.temp_dirname, 'metadata.rdf')
+        metadata_format = OmexMetadataOutputFormat.rdfxml_abbrev
+        with open(model_filename, 'w') as file:
+            file.write('<sbml></sbml')
+        with self.assertRaisesRegex(RuntimeError, 'could not be extracted'):
+            build_omex_meta_file_for_model(model_filename, metadata_filename, metadata_format)
+
+        model_filename = os.path.join(self.temp_dirname, 'model.xml')
+        metadata_filename = os.path.join(self.temp_dirname, 'metadata.rdf')
+        metadata_format = OmexMetadataOutputFormat.rdfxml_abbrev
+        with open(model_filename, 'w') as file:
+            file.write('<sbml></sbml>')
+        with self.assertRaisesRegex(RuntimeError, 'could not be read'):
             build_omex_meta_file_for_model(model_filename, metadata_filename, metadata_format)
 
         model_filename = os.path.join(self.FIXTURE_DIRNAME, 'omex-metadata', 'simple-regulation.xml')


### PR DESCRIPTION
The problem here stemmed from pyomexmeta failing to read the XML for some generated files.  We can work on that separately, but in the meantime, this wraps that call in a try/catch block that simply reports a failure to read the file instead of halting.

In addition, this fixes an issue I found on my own runs where UTF-8 characters were confusing the writer:  we now explicitly tell the writer that we are using utf-8.