### PR TITLE
fix (cellml): use integers for the number of steps

### DIFF
--- a/biosimulators_utils/model_lang/cellml/utils.py
+++ b/biosimulators_utils/model_lang/cellml/utils.py
@@ -100,7 +100,7 @@ def get_parameters_variables_for_simulation_version_1(model, xml_root, simulatio
             initial_time=0.,
             output_start_time=0.,
             output_end_time=1.,
-            number_of_steps=10.,
+            number_of_steps=10,
             algorithm=Algorithm(
                 kisao_id=algorithm_kisao_id or 'KISAO_0000019',
             ),
@@ -180,7 +180,7 @@ def get_parameters_variables_for_simulation_version_2(model, xml_root, simulatio
             initial_time=0.,
             output_start_time=0.,
             output_end_time=1.,
-            number_of_steps=10.,
+            number_of_steps=10,
             algorithm=Algorithm(
                 kisao_id=algorithm_kisao_id or 'KISAO_0000019',
             ),
@@ -188,7 +188,7 @@ def get_parameters_variables_for_simulation_version_2(model, xml_root, simulatio
     else:
         sim = OneStepSimulation(
             id='simulation',
-            step=1.,
+            step=1,
             algorithm=Algorithm(
                 kisao_id=algorithm_kisao_id or 'KISAO_0000019',
             ),


### PR DESCRIPTION
**What bugs does this PR fix?**

Uses integers for the number of steps in a UniformTimeCourse to prevent underlying libSedML from raising type error. (closes #106)
**How have you tested this PR?**
Used the method to generate SED-ML files


