### PR TITLE
substitute '**' for '^' for python execution of sedml changes

### DIFF
--- a/biosimulators_utils/sedml/math.py
+++ b/biosimulators_utils/sedml/math.py
@@ -175,6 +175,7 @@ def compile_math(math):
             math
             .replace('&&', 'and')
             .replace('||', 'or')
+            .replace('^', '**')
         )
 
     math_node = evalidate.evalidate(math,

--- a/tests/sedml/test_sedml_math.py
+++ b/tests/sedml/test_sedml_math.py
@@ -1,6 +1,9 @@
-from biosimulators_utils.sedml import math as sedml_math
 import math
 import unittest
+
+import libsedml
+
+from biosimulators_utils.sedml import math as sedml_math
 
 
 class MathTestCase(unittest.TestCase):
@@ -13,6 +16,26 @@ class MathTestCase(unittest.TestCase):
         self.assertEqual(sedml_math.piecewise(1, False, 2, True, 3), 2)
         self.assertEqual(sedml_math.piecewise(1, False, 2, False, 3), 3)
         self.assertTrue(math.isnan(sedml_math.piecewise(1, False, 2, False)))
+
+    def test_python_infix_operator_substitutions(self):
+        test_cases = {
+            "2.0 ^ 3": 8.0,
+            "2 ^ 3": 8.0,
+            "2.0 ^ 3.0": 8.0,
+            "2 ^ 3.0": 8.0,
+            "0.0 && 0.0": 0.0,
+            "1.0 && 0.0": 0.0,
+            "1 && 1": 1.0,
+            "0.0 || 0.0": 0.0,
+            "1.0 || 0.0": 1.0,
+            "1 || 1": 1.0
+        }
+        for (orig_infix, expected_value) in test_cases.items():
+            # round trip to libsedml to ensure proper integration
+            ast_node = libsedml.parseL3Formula(orig_infix)
+            infix: str = libsedml.formulaToL3String(ast_node)
+            compiled_math = sedml_math.compile_math(infix)
+            self.assertEqual(sedml_math.eval_math(infix, compiled_math, {}), expected_value)
 
     def test_compile_eval_math(self):
         math = '1 + 2'


### PR DESCRIPTION
### fix SEDML validation error when model changes include power operator
see Issue 118: "[infix math from libsedml uses '^' instead of '**' in python, validation fails](https://github.com/biosimulators/Biosimulators_utils/issues/118)

#### Background
if the MathML for a computeChange contains a <pow/> operator, the infix notation from returned by libsedml.formulaToL3String() represents the pow operator as '^', but the corresponding python syntax is '**'. During validation of a computed change, this infix representation (stored in change.math) is evaluated and fails if the operands are not compatible with bitwise XOR (e.g. if either operand is a float)

compile_math() function in `Biosimulators_utils/sedml/math.py` now replaces '^' with '**' in infix strings before python evaluation.  It is assumed that SEDML MathML will not support the bitwise XOR operator.

**Fixes the following bug**
* Adds Math infix notation support for power operator which currently fails SEDML validation (closes #118)

**Testing**
* A new unit test was added to exercise all math infix string replacements (for `AND`, `OR`, `POWER`). 
 See `MathTestCase.test_python_infix_operator_substitutions()` in /tests/sedml/test_sedml_math.py.
