### PR TITLE
fix: NumPy slice error

### DIFF
--- a/biosimulators_utils/model_lang/cellml/utils.py
+++ b/biosimulators_utils/model_lang/cellml/utils.py
@@ -131,7 +131,7 @@ def get_parameters_variables_for_simulation_version_1(model, xml_root, simulatio
             private_interface_in = variable.attrib.get('private_interface', None) == 'in'
             variable_is_hidden = private_interface_in or public_interface_in
 
-            if(variable_is_hidden and observable_only):
+            if variable_is_hidden and observable_only:
                 continue
             initial_value = variable.attrib.get('initial_value', None)
             if initial_value is not None:

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -267,19 +267,7 @@ class ReportReader(object):
                         data_set_shape = data_set_shapes[i_data_set]
                         data_set_slice = [slice(0, dim_len) for dim_len in data_set_shape] + \
                             [slice(0, 1)] * (data_set_ndim - len(data_set_shape))
-
-                        # This is the numpy bug!!
-                        # IndexError: only integers, slices (`:`), ellipsis (`...`),
-                        # numpy.newaxis (`None`) and integer or boolean arrays are valid indices
-                        print(f'NUMPY BUG! '
-                              f'data_set.id = {data_set.id}, '
-                              f'i_data_set = {i_data_set}, '
-                              f'data_set_slice = {data_set_slice}, '
-                              f'data_set_ndim = {data_set_ndim}, '
-                              f'data_set_shape = {data_set_shape}, '
-                              f'data_set_data_type = {data_set_data_type}, '
-                              f'data_set_results = {data_set_results}, '
-                              )
+                        
                         if data_set_ndim == 2:
                             results[data_set.id] = (
                                 data_set_results[i_data_set]

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -275,10 +275,13 @@ class ReportReader(object):
                               f'data_set.id = {data_set.id}, '
                               f'i_data_set = {i_data_set}, '
                               f'data_set_slice = {data_set_slice}, '
+                              f'data_set_ndim = {data_set_ndim}'
                               f'data_set_shape = {data_set_shape}, '
-                              f'data_set_data_type = {data_set_data_type}')
+                              f'data_set_data_type = {data_set_data_type}'
+                              f'data_set_results = {data_set_results}'
+                              )
                         results[data_set.id] = (
-                            data_set_results[i_data_set][data_set_slice]
+                            data_set_results[i_data_set][data_set_slice[0].start:data_set_slice[0].stop]
                             .reshape(data_set_shape)
                             .astype(data_set_data_type)
                         )

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -267,6 +267,16 @@ class ReportReader(object):
                         data_set_shape = data_set_shapes[i_data_set]
                         data_set_slice = [slice(0, dim_len) for dim_len in data_set_shape] + \
                             [slice(0, 1)] * (data_set_ndim - len(data_set_shape))
+
+
+                        # This is the numpy bug!!
+                        # IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
+                        print(f'NUMPY BUG! '
+                              f'data_set.id = {data_set.id}, '
+                              f'i_data_set = {i_data_set}, '
+                              f'data_set_slice = {data_set_slice}, '
+                              f'data_set_shape = {data_set_shape}, '
+                              f'data_set_data_type = {data_set_data_type}')
                         results[data_set.id] = (
                             data_set_results[i_data_set][data_set_slice]
                             .reshape(data_set_shape)

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -267,7 +267,6 @@ class ReportReader(object):
                         data_set_shape = data_set_shapes[i_data_set]
                         data_set_slice = [slice(0, dim_len) for dim_len in data_set_shape] + \
                             [slice(0, 1)] * (data_set_ndim - len(data_set_shape))
-                        
                         if data_set_ndim == 2:
                             results[data_set.id] = (
                                 data_set_results[i_data_set]

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -275,17 +275,26 @@ class ReportReader(object):
                               f'data_set.id = {data_set.id}, '
                               f'i_data_set = {i_data_set}, '
                               f'data_set_slice = {data_set_slice}, '
-                              f'data_set_ndim = {data_set_ndim}'
+                              f'data_set_ndim = {data_set_ndim}, '
                               f'data_set_shape = {data_set_shape}, '
-                              f'data_set_data_type = {data_set_data_type}'
-                              f'data_set_results = {data_set_results}'
+                              f'data_set_data_type = {data_set_data_type}, '
+                              f'data_set_results = {data_set_results}, '
                               )
-                        results[data_set.id] = (
-                            data_set_results[i_data_set][data_set_slice[0].start:data_set_slice[0].stop]
-                            .reshape(data_set_shape)
-                            .astype(data_set_data_type)
-                        )
-
+                        if data_set_ndim == 2:
+                            results[data_set.id] = (
+                                data_set_results[i_data_set]
+                                [data_set_slice[0].start:data_set_slice[0].stop]
+                                [data_set_slice[1].start:data_set_slice[1].stop]
+                                .reshape(data_set_shape)
+                                .astype(data_set_data_type)
+                            )
+                        else:
+                            results[data_set.id] = (
+                                data_set_results[i_data_set]
+                                [data_set_slice[0].start:data_set_slice[0].stop]
+                                .reshape(data_set_shape)
+                                .astype(data_set_data_type)
+                            )
             file_data_set_ids = set(file_data_set_ids)
 
         else:

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -283,8 +283,8 @@ class ReportReader(object):
                         if data_set_ndim == 2:
                             results[data_set.id] = (
                                 data_set_results[i_data_set]
-                                [data_set_slice[0].start:data_set_slice[0].stop]
-                                [data_set_slice[1].start:data_set_slice[1].stop]
+                                [data_set_slice[0].start:data_set_slice[0].stop,
+                                data_set_slice[1].start:data_set_slice[1].stop]
                                 .reshape(data_set_shape)
                                 .astype(data_set_data_type)
                             )

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -284,7 +284,7 @@ class ReportReader(object):
                             results[data_set.id] = (
                                 data_set_results[i_data_set]
                                 [data_set_slice[0].start:data_set_slice[0].stop,
-                                data_set_slice[1].start:data_set_slice[1].stop]
+                                    data_set_slice[1].start:data_set_slice[1].stop]
                                 .reshape(data_set_shape)
                                 .astype(data_set_data_type)
                             )

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -268,9 +268,9 @@ class ReportReader(object):
                         data_set_slice = [slice(0, dim_len) for dim_len in data_set_shape] + \
                             [slice(0, 1)] * (data_set_ndim - len(data_set_shape))
 
-
                         # This is the numpy bug!!
-                        # IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
+                        # IndexError: only integers, slices (`:`), ellipsis (`...`),
+                        # numpy.newaxis (`None`) and integer or boolean arrays are valid indices
                         print(f'NUMPY BUG! '
                               f'data_set.id = {data_set.id}, '
                               f'i_data_set = {i_data_set}, '

--- a/biosimulators_utils/viz/io.py
+++ b/biosimulators_utils/viz/io.py
@@ -116,7 +116,7 @@ def write_plot_3d(plot, data_generator_results, base_path, rel_path, format=VizF
         colormaps (:obj:`list` of :obj:`matplotlib.colors.LinearSegmentedColormap`, optional): colormaps
     """
     figure = pyplot.figure()
-    figure.gca(projection='3d')
+    axes = figure.gca(projection='3d')
 
     x_names = set()
     y_names = set()

--- a/biosimulators_utils/viz/io.py
+++ b/biosimulators_utils/viz/io.py
@@ -116,7 +116,7 @@ def write_plot_3d(plot, data_generator_results, base_path, rel_path, format=VizF
         colormaps (:obj:`list` of :obj:`matplotlib.colors.LinearSegmentedColormap`, optional): colormaps
     """
     figure = pyplot.figure()
-    axes = figure.axes(projection='3d')
+    figure.gca(projection='3d')
 
     x_names = set()
     y_names = set()

--- a/biosimulators_utils/viz/io.py
+++ b/biosimulators_utils/viz/io.py
@@ -116,7 +116,7 @@ def write_plot_3d(plot, data_generator_results, base_path, rel_path, format=VizF
         colormaps (:obj:`list` of :obj:`matplotlib.colors.LinearSegmentedColormap`, optional): colormaps
     """
     figure = pyplot.figure()
-    axes = figure.gca()
+    axes = figure.axes(projection='3d')
 
     x_names = set()
     y_names = set()

--- a/biosimulators_utils/viz/io.py
+++ b/biosimulators_utils/viz/io.py
@@ -116,7 +116,7 @@ def write_plot_3d(plot, data_generator_results, base_path, rel_path, format=VizF
         colormaps (:obj:`list` of :obj:`matplotlib.colors.LinearSegmentedColormap`, optional): colormaps
     """
     figure = pyplot.figure()
-    axes = figure.gca(projection='3d')
+    axes = figure.add_subplot(projection='3d')
 
     x_names = set()
     y_names = set()

--- a/biosimulators_utils/viz/io.py
+++ b/biosimulators_utils/viz/io.py
@@ -116,7 +116,7 @@ def write_plot_3d(plot, data_generator_results, base_path, rel_path, format=VizF
         colormaps (:obj:`list` of :obj:`matplotlib.colors.LinearSegmentedColormap`, optional): colormaps
     """
     figure = pyplot.figure()
-    axes = figure.gca(projection='3d')
+    axes = figure.gca()
 
     x_names = set()
     y_names = set()


### PR DESCRIPTION
This PR fixes a long-standing NumPy error in which a `slice` object can no longer be used as an index. Instead, I am pulling the ranges out of the `slice` object and using them directly. 

I also fixed some listing errors and matplotlib deprecation errors, but left 4 tests still failing, down from 13 failing before this PR: 

1. FAILED tests/model_lang/bngl/test_bngl_utils.py::BgnlUtilsTestCase::test_get_parameters_variables_for_simulation_with_empty_sample_times - AssertionError: “failed to parse action” does not match “Model file `/home/runner/work/Biosimulators_utils/Biosimulators_utils/tests/model_lang/bngl/../../fixtures/bngl/empty-sample-times.bngl` is not a valid BNGL or BNGL XML file.
2. FAILED tests/sedml/test_sedml_validation.py::ValidationTestCase::test_validate_calculation - AssertionError: ‘The syntax’ not found in ‘- The mathematical expression `a * ` is invalid.\n  - unexpected EOF while parsing (<usercode>, line 1)’
3. FAILED tests/combine/test_combine_exec.py::ExecCombineTestCase::test_1 - AssertionError: None != {‘sim.sedml’: {‘report1’: ‘ABC’, ‘report2’: ‘DEF’}}
4. FAILED tests/combine/test_combine_exec.py::ExecCombineTestCase::test_2 - AssertionError: Lists differ: [‘log.yml’] != [‘dir1’, ‘log.yml’, ‘plots.zip’, ‘reports.zip’]