### PR TITLE
Fix numpy bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   getVersionNumber:
     name: Get version number
     if: "startsWith(github.ref, 'refs/tags/') && !contains(github.event.head_commit.message, '[skip ci]') && github.actor != 'allcontributors'"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       version: ${{ steps.get-version-number.outputs.version }}
     steps:
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Lint, test, and compile documentation
     if: "!contains(github.event.head_commit.message, '[skip ci]') && github.actor != 'allcontributors'"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -129,7 +129,7 @@ jobs:
   release:
     name: Release a new version
     needs: [getVersionNumber, build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Command-line application and high-level utilities for reading, writing, validati
 
 ### Requirements
 * Python >= 3.7
-* pip
+* pip (latest)
 
 ### Optional requirements
 

--- a/biosimulators_utils/combine/io.py
+++ b/biosimulators_utils/combine/io.py
@@ -129,7 +129,7 @@ class CombineArchiveReader(object):
         self.errors = []
         self.warnings = []
 
-    def run(self, in_file:str, out_dir:str, include_omex_metadata_files:bool=True, config:Config=None) -> CombineArchive:
+    def run(self, in_file: str, out_dir: str, include_omex_metadata_files: bool = True, config: Config = None) -> CombineArchive:
         """ Read an archive from a file
 
         Args:
@@ -202,11 +202,11 @@ class CombineArchiveReader(object):
             archive.contents.append(content)
 
         # extract files
-        #archive_comb.extractTo(out_dir) # libcombine incorrectly extracts files as directories.
-        
-        # Backup extraction
+
         with Zip(in_file, 'r') as zip_archive:
             zip_archive.extractall(path=out_dir)
+
+#        archive_comb.extractTo(out_dir) # libcombine incorrectly extracts files as directories.
 
         # read metadata files skipped by libCOMBINE
         content_locations = set(os.path.relpath(content.location, '.') for content in archive.contents)

--- a/biosimulators_utils/combine/io.py
+++ b/biosimulators_utils/combine/io.py
@@ -12,6 +12,7 @@ from ..archive.io import ArchiveReader
 from ..config import get_config, Config  # noqa: F401
 from ..utils.core import flatten_nested_list_of_strings
 from ..warnings import warn, BioSimulatorsWarning
+from zipfile import ZipFile as Zip
 import libcombine
 import os
 import re
@@ -128,7 +129,7 @@ class CombineArchiveReader(object):
         self.errors = []
         self.warnings = []
 
-    def run(self, in_file, out_dir, include_omex_metadata_files=True, config=None):
+    def run(self, in_file:str, out_dir:str, include_omex_metadata_files:bool=True, config:Config=None) -> CombineArchive:
         """ Read an archive from a file
 
         Args:
@@ -201,7 +202,11 @@ class CombineArchiveReader(object):
             archive.contents.append(content)
 
         # extract files
-        archive_comb.extractTo(out_dir)
+        #archive_comb.extractTo(out_dir) # libcombine incorrectly extracts files as directories.
+        
+        # Backup extraction
+        with Zip(in_file, 'r') as zip_archive:
+            zip_archive.extractall(path=out_dir)
 
         # read metadata files skipped by libCOMBINE
         content_locations = set(os.path.relpath(content.location, '.') for content in archive.contents)

--- a/biosimulators_utils/combine/validation.py
+++ b/biosimulators_utils/combine/validation.py
@@ -11,6 +11,7 @@ from ..omex_meta.io import read_omex_meta_files_for_archive
 from ..sedml.io import SedmlSimulationReader
 from .data_model import CombineArchive, CombineArchiveContent, CombineArchiveContentFormat, CombineArchiveContentFormatPattern  # noqa: F401
 from .utils import get_sedml_contents
+from zipfile import ZipFile
 import imghdr
 import os
 import re
@@ -22,14 +23,14 @@ __all__ = [
 ]
 
 
-def validate(archive, archive_dirname,
-             include_all_sed_docs_when_no_sed_doc_is_master=True,
-             always_include_all_sed_docs=False,
-             formats_to_validate=[
+def validate(archive:CombineArchive, archive_dirname:str,
+             include_all_sed_docs_when_no_sed_doc_is_master:bool=True,
+             always_include_all_sed_docs:bool=False,
+             formats_to_validate:"list[CombineArchiveContentFormat]"=[
                  CombineArchiveContentFormat.SED_ML,
              ],
-             validate_models_with_languages=True,
-             config=None):
+             validate_models_with_languages:bool=True,
+             config:Config=None):
     """ Validate a COMBINE/OMEX archive and the SED-ML and model documents it contains
 
     Args:
@@ -95,7 +96,8 @@ def validate(archive, archive_dirname,
 
             if isinstance(content, CombineArchiveContent):
                 if content.location:
-                    if not os.path.isfile(os.path.join(archive_dirname, content.location)):
+                    abs_path = os.path.join(archive_dirname, content.location)
+                    if not os.path.isfile(abs_path):
                         content_errors.append(['Location is not a file.'])
 
                 else:

--- a/biosimulators_utils/combine/validation.py
+++ b/biosimulators_utils/combine/validation.py
@@ -11,7 +11,6 @@ from ..omex_meta.io import read_omex_meta_files_for_archive
 from ..sedml.io import SedmlSimulationReader
 from .data_model import CombineArchive, CombineArchiveContent, CombineArchiveContentFormat, CombineArchiveContentFormatPattern  # noqa: F401
 from .utils import get_sedml_contents
-from zipfile import ZipFile
 import imghdr
 import os
 import re
@@ -23,14 +22,14 @@ __all__ = [
 ]
 
 
-def validate(archive:CombineArchive, archive_dirname:str,
-             include_all_sed_docs_when_no_sed_doc_is_master:bool=True,
-             always_include_all_sed_docs:bool=False,
-             formats_to_validate:"list[CombineArchiveContentFormat]"=[
+def validate(archive: CombineArchive, archive_dirname: str,
+             include_all_sed_docs_when_no_sed_doc_is_master: bool = True,
+             always_include_all_sed_docs: bool = False,
+             formats_to_validate: "list[CombineArchiveContentFormat]" = [
                  CombineArchiveContentFormat.SED_ML,
              ],
-             validate_models_with_languages:bool=True,
-             config:Config=None):
+             validate_models_with_languages: bool = True,
+             config: Config = None):
     """ Validate a COMBINE/OMEX archive and the SED-ML and model documents it contains
 
     Args:

--- a/biosimulators_utils/model_lang/bngl/validation.py
+++ b/biosimulators_utils/model_lang/bngl/validation.py
@@ -27,7 +27,7 @@ def validate_model(filename, name=None, config=None):
         :obj:`tuple`:
 
             * nested :obj:`list` of :obj:`str`: nested list of errors (e.g., required ids missing or ids not unique)
-            * nested :obj:`list` of :obj:`str`: nested list of errors (e.g., required ids missing or ids not unique)
+            * nested :obj:`list` of :obj:`str`: nested list of warnings (e.g., required ids missing or ids not unique)
             * :obj:`bionetgen.xmlapi.model.bngmodel`: model
     """
     errors = []

--- a/biosimulators_utils/model_lang/cellml/utils.py
+++ b/biosimulators_utils/model_lang/cellml/utils.py
@@ -131,7 +131,7 @@ def get_parameters_variables_for_simulation_version_1(model, xml_root, simulatio
             private_interface_in = variable.attrib.get('private_interface', None) == 'in'
             variable_is_hidden = private_interface_in or public_interface_in
 
-            if(variable_is_hidden and observable_only):
+            if variable_is_hidden and observable_only:
                 continue
             initial_value = variable.attrib.get('initial_value', None)
             if initial_value is not None:

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -267,19 +267,7 @@ class ReportReader(object):
                         data_set_shape = data_set_shapes[i_data_set]
                         data_set_slice = [slice(0, dim_len) for dim_len in data_set_shape] + \
                             [slice(0, 1)] * (data_set_ndim - len(data_set_shape))
-
-                        # This is the numpy bug!!
-                        # IndexError: only integers, slices (`:`), ellipsis (`...`),
-                        # numpy.newaxis (`None`) and integer or boolean arrays are valid indices
-                        print(f'NUMPY BUG! '
-                              f'data_set.id = {data_set.id}, '
-                              f'i_data_set = {i_data_set}, '
-                              f'data_set_slice = {data_set_slice}, '
-                              f'data_set_ndim = {data_set_ndim}, '
-                              f'data_set_shape = {data_set_shape}, '
-                              f'data_set_data_type = {data_set_data_type}, '
-                              f'data_set_results = {data_set_results}, '
-                              )
+                        
                         if data_set_ndim == 2:
                             results[data_set.id] = (
                                 data_set_results[i_data_set]

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -265,8 +265,8 @@ class ReportReader(object):
                         results[data_set.id] = None
                     else:
                         data_set_shape = data_set_shapes[i_data_set]
-                        data_set_slice = tuple([slice(0, dim_len) for dim_len in data_set_shape] + 
-                            [slice(0, 1)] * (data_set_ndim - len(data_set_shape)))
+                        data_set_slice = tuple( [slice(0, dim_len) for dim_len in data_set_shape] +
+                                                [slice(0, 1)] * (data_set_ndim - len(data_set_shape)))
                         results[data_set.id] = (
                             data_set_results[i_data_set][data_set_slice]
                             .reshape(data_set_shape)

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -275,10 +275,13 @@ class ReportReader(object):
                               f'data_set.id = {data_set.id}, '
                               f'i_data_set = {i_data_set}, '
                               f'data_set_slice = {data_set_slice}, '
+                              f'data_set_ndim = {data_set_ndim}'
                               f'data_set_shape = {data_set_shape}, '
-                              f'data_set_data_type = {data_set_data_type}')
+                              f'data_set_data_type = {data_set_data_type}'
+                              f'data_set_results = {data_set_results}'
+                              )
                         results[data_set.id] = (
-                            data_set_results[i_data_set][data_set_slice]
+                            data_set_results[i_data_set][data_set_slice[0].start:data_set_slice[0].stop]
                             .reshape(data_set_shape)
                             .astype(data_set_data_type)
                         )

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -267,6 +267,16 @@ class ReportReader(object):
                         data_set_shape = data_set_shapes[i_data_set]
                         data_set_slice = [slice(0, dim_len) for dim_len in data_set_shape] + \
                             [slice(0, 1)] * (data_set_ndim - len(data_set_shape))
+
+
+                        # This is the numpy bug!!
+                        # IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
+                        print(f'NUMPY BUG! '
+                              f'data_set.id = {data_set.id}, '
+                              f'i_data_set = {i_data_set}, '
+                              f'data_set_slice = {data_set_slice}, '
+                              f'data_set_shape = {data_set_shape}, '
+                              f'data_set_data_type = {data_set_data_type}')
                         results[data_set.id] = (
                             data_set_results[i_data_set][data_set_slice]
                             .reshape(data_set_shape)

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -267,7 +267,6 @@ class ReportReader(object):
                         data_set_shape = data_set_shapes[i_data_set]
                         data_set_slice = [slice(0, dim_len) for dim_len in data_set_shape] + \
                             [slice(0, 1)] * (data_set_ndim - len(data_set_shape))
-                        
                         if data_set_ndim == 2:
                             results[data_set.id] = (
                                 data_set_results[i_data_set]

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -275,17 +275,26 @@ class ReportReader(object):
                               f'data_set.id = {data_set.id}, '
                               f'i_data_set = {i_data_set}, '
                               f'data_set_slice = {data_set_slice}, '
-                              f'data_set_ndim = {data_set_ndim}'
+                              f'data_set_ndim = {data_set_ndim}, '
                               f'data_set_shape = {data_set_shape}, '
-                              f'data_set_data_type = {data_set_data_type}'
-                              f'data_set_results = {data_set_results}'
+                              f'data_set_data_type = {data_set_data_type}, '
+                              f'data_set_results = {data_set_results}, '
                               )
-                        results[data_set.id] = (
-                            data_set_results[i_data_set][data_set_slice[0].start:data_set_slice[0].stop]
-                            .reshape(data_set_shape)
-                            .astype(data_set_data_type)
-                        )
-
+                        if data_set_ndim == 2:
+                            results[data_set.id] = (
+                                data_set_results[i_data_set]
+                                [data_set_slice[0].start:data_set_slice[0].stop]
+                                [data_set_slice[1].start:data_set_slice[1].stop]
+                                .reshape(data_set_shape)
+                                .astype(data_set_data_type)
+                            )
+                        else:
+                            results[data_set.id] = (
+                                data_set_results[i_data_set]
+                                [data_set_slice[0].start:data_set_slice[0].stop]
+                                .reshape(data_set_shape)
+                                .astype(data_set_data_type)
+                            )
             file_data_set_ids = set(file_data_set_ids)
 
         else:

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -265,23 +265,14 @@ class ReportReader(object):
                         results[data_set.id] = None
                     else:
                         data_set_shape = data_set_shapes[i_data_set]
-                        data_set_slice = [slice(0, dim_len) for dim_len in data_set_shape] + \
-                            [slice(0, 1)] * (data_set_ndim - len(data_set_shape))
-                        if data_set_ndim == 2:
-                            results[data_set.id] = (
-                                data_set_results[i_data_set]
-                                [data_set_slice[0].start:data_set_slice[0].stop,
-                                    data_set_slice[1].start:data_set_slice[1].stop]
-                                .reshape(data_set_shape)
-                                .astype(data_set_data_type)
-                            )
-                        else:
-                            results[data_set.id] = (
-                                data_set_results[i_data_set]
-                                [data_set_slice[0].start:data_set_slice[0].stop]
-                                .reshape(data_set_shape)
-                                .astype(data_set_data_type)
-                            )
+                        data_set_slice = tuple([slice(0, dim_len) for dim_len in data_set_shape] + \
+                            [slice(0, 1)] * (data_set_ndim - len(data_set_shape)))
+                        results[data_set.id] = (
+                            data_set_results[i_data_set][data_set_slice]
+                            .reshape(data_set_shape)
+                            .astype(data_set_data_type)
+                        )
+
             file_data_set_ids = set(file_data_set_ids)
 
         else:

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -265,7 +265,8 @@ class ReportReader(object):
                         results[data_set.id] = None
                     else:
                         data_set_shape = data_set_shapes[i_data_set]
-                        data_set_slice = tuple([slice(0, dim_len) for dim_len in data_set_shape] + [slice(0, 1)] * (data_set_ndim - len(data_set_shape)))
+                        data_set_slice = tuple([slice(0, dim_len) for dim_len in data_set_shape] + 
+                            [slice(0, 1)] * (data_set_ndim - len(data_set_shape)))
                         results[data_set.id] = (
                             data_set_results[i_data_set][data_set_slice]
                             .reshape(data_set_shape)

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -283,8 +283,8 @@ class ReportReader(object):
                         if data_set_ndim == 2:
                             results[data_set.id] = (
                                 data_set_results[i_data_set]
-                                [data_set_slice[0].start:data_set_slice[0].stop]
-                                [data_set_slice[1].start:data_set_slice[1].stop]
+                                [data_set_slice[0].start:data_set_slice[0].stop,
+                                data_set_slice[1].start:data_set_slice[1].stop]
                                 .reshape(data_set_shape)
                                 .astype(data_set_data_type)
                             )

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -284,7 +284,7 @@ class ReportReader(object):
                             results[data_set.id] = (
                                 data_set_results[i_data_set]
                                 [data_set_slice[0].start:data_set_slice[0].stop,
-                                data_set_slice[1].start:data_set_slice[1].stop]
+                                    data_set_slice[1].start:data_set_slice[1].stop]
                                 .reshape(data_set_shape)
                                 .astype(data_set_data_type)
                             )

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -266,7 +266,7 @@ class ReportReader(object):
                     else:
                         data_set_shape = data_set_shapes[i_data_set]
                         data_set_slice = tuple([slice(0, dim_len) for dim_len in data_set_shape] +
-                                                [slice(0, 1)] * (data_set_ndim - len(data_set_shape)))
+                                               [slice(0, 1)] * (data_set_ndim - len(data_set_shape)))
                         results[data_set.id] = (
                             data_set_results[i_data_set][data_set_slice]
                             .reshape(data_set_shape)

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -265,7 +265,7 @@ class ReportReader(object):
                         results[data_set.id] = None
                     else:
                         data_set_shape = data_set_shapes[i_data_set]
-                        data_set_slice = tuple( [slice(0, dim_len) for dim_len in data_set_shape] +
+                        data_set_slice = tuple([slice(0, dim_len) for dim_len in data_set_shape] +
                                                 [slice(0, 1)] * (data_set_ndim - len(data_set_shape)))
                         results[data_set.id] = (
                             data_set_results[i_data_set][data_set_slice]

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -265,8 +265,7 @@ class ReportReader(object):
                         results[data_set.id] = None
                     else:
                         data_set_shape = data_set_shapes[i_data_set]
-                        data_set_slice = tuple([slice(0, dim_len) for dim_len in data_set_shape] + \
-                            [slice(0, 1)] * (data_set_ndim - len(data_set_shape)))
+                        data_set_slice = tuple([slice(0, dim_len) for dim_len in data_set_shape] + [slice(0, 1)] * (data_set_ndim - len(data_set_shape)))
                         results[data_set.id] = (
                             data_set_results[i_data_set][data_set_slice]
                             .reshape(data_set_shape)

--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -268,9 +268,9 @@ class ReportReader(object):
                         data_set_slice = [slice(0, dim_len) for dim_len in data_set_shape] + \
                             [slice(0, 1)] * (data_set_ndim - len(data_set_shape))
 
-
                         # This is the numpy bug!!
-                        # IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
+                        # IndexError: only integers, slices (`:`), ellipsis (`...`),
+                        # numpy.newaxis (`None`) and integer or boolean arrays are valid indices
                         print(f'NUMPY BUG! '
                               f'data_set.id = {data_set.id}, '
                               f'i_data_set = {i_data_set}, '

--- a/biosimulators_utils/sedml/math.py
+++ b/biosimulators_utils/sedml/math.py
@@ -161,6 +161,7 @@ VALID_MATH_EXPRESSION_NODES = [
     'Constant',
     'Expression',
     'BinOp',
+    'BoolOp',
     'Name',
     'Load',
 ]

--- a/biosimulators_utils/sedml/math.py
+++ b/biosimulators_utils/sedml/math.py
@@ -146,6 +146,7 @@ VALID_MATH_EXPRESSION_NODES = [
     'Lt',
     'GtE',
     'LtE',
+    'Add',
     'Sub',
     'Mult',
     'Div',
@@ -158,6 +159,10 @@ VALID_MATH_EXPRESSION_NODES = [
     'BitXor',
     'Call',
     'Constant',
+    'Expression',
+    'BinOp',
+    'Name',
+    'Load',
 ]
 
 
@@ -178,7 +183,7 @@ def compile_math(math):
         )
 
     math_node = evalidate.evalidate(math,
-                                    addnodes=VALID_MATH_EXPRESSION_NODES,
+                                    safenodes=VALID_MATH_EXPRESSION_NODES,
                                     funcs=MATHEMATICAL_FUNCTIONS.keys())
     compiled_math = compile(math_node, '<math>', 'eval')
     return compiled_math

--- a/biosimulators_utils/sedml/math.py
+++ b/biosimulators_utils/sedml/math.py
@@ -184,7 +184,7 @@ def compile_math(math):
         )
 
     math_node = evalidate.evalidate(math,
-                                    safenodes=VALID_MATH_EXPRESSION_NODES,
+                                    addnodes=VALID_MATH_EXPRESSION_NODES,
                                     funcs=MATHEMATICAL_FUNCTIONS.keys())
     compiled_math = compile(math_node, '<math>', 'eval')
     return compiled_math

--- a/biosimulators_utils/sedml/math.py
+++ b/biosimulators_utils/sedml/math.py
@@ -146,7 +146,6 @@ VALID_MATH_EXPRESSION_NODES = [
     'Lt',
     'GtE',
     'LtE',
-    'Add',
     'Sub',
     'Mult',
     'Div',
@@ -159,11 +158,6 @@ VALID_MATH_EXPRESSION_NODES = [
     'BitXor',
     'Call',
     'Constant',
-    'Expression',
-    'BinOp',
-    'BoolOp',
-    'Name',
-    'Load',
 ]
 
 

--- a/biosimulators_utils/sedml/validation.py
+++ b/biosimulators_utils/sedml/validation.py
@@ -1771,11 +1771,11 @@ def validate_calculation(calculation):
 
         try:
             compiled_math = compile_math(calculation.math)
-        except TypeError as exception:
+        except TypeError:
             errors.append(['The mathematical expression must be a `string`, not a `{}`.'.format(calculation.math.__class__)])
             return (errors, warnings)
         except (SyntaxError, CompilationException) as exception:
-            errors.append(['The syntax of the mathematical expression `{}` is invalid.'.format(calculation.math)])
+            errors.append(['The syntax of the mathematical expression `{}` is invalid.'.format(calculation.math), [[str(exception)]]])
             return (errors, warnings)
         except ValidationException as exception:
             errors.append(['The mathematical expression `{}` uses forbidden operations.'.format(calculation.math), [[str(exception)]]])

--- a/biosimulators_utils/sedml/validation.py
+++ b/biosimulators_utils/sedml/validation.py
@@ -27,6 +27,7 @@ from .utils import (append_all_nested_children_to_doc, get_range_len,
                     get_data_generators_for_output, get_variables_for_data_generators,
                     get_task_results_shape)
 from kisao.data_model import TermType as KisaoTermType
+from evalidate import CompilationException, ValidationException
 import collections
 import copy
 import lxml.etree
@@ -1770,11 +1771,14 @@ def validate_calculation(calculation):
 
         try:
             compiled_math = compile_math(calculation.math)
-        except TypeError:
+        except TypeError as exception:
             errors.append(['The mathematical expression must be a `string`, not a `{}`.'.format(calculation.math.__class__)])
             return (errors, warnings)
-        except SyntaxError:
+        except (SyntaxError, CompilationException) as exception:
             errors.append(['The syntax of the mathematical expression `{}` is invalid.'.format(calculation.math)])
+            return (errors, warnings)
+        except ValidationException as exception:
+            errors.append(['The mathematical expression `{}` uses forbidden operations.'.format(calculation.math), [[str(exception)]]])
             return (errors, warnings)
         except Exception as exception:
             errors.append(['The mathematical expression `{}` is invalid.'.format(calculation.math), [[str(exception)]]])

--- a/biosimulators_utils/viz/io.py
+++ b/biosimulators_utils/viz/io.py
@@ -116,7 +116,7 @@ def write_plot_3d(plot, data_generator_results, base_path, rel_path, format=VizF
         colormaps (:obj:`list` of :obj:`matplotlib.colors.LinearSegmentedColormap`, optional): colormaps
     """
     figure = pyplot.figure()
-    figure.gca(projection='3d')
+    axes = figure.gca(projection='3d')
 
     x_names = set()
     y_names = set()

--- a/biosimulators_utils/viz/io.py
+++ b/biosimulators_utils/viz/io.py
@@ -116,7 +116,7 @@ def write_plot_3d(plot, data_generator_results, base_path, rel_path, format=VizF
         colormaps (:obj:`list` of :obj:`matplotlib.colors.LinearSegmentedColormap`, optional): colormaps
     """
     figure = pyplot.figure()
-    axes = figure.axes(projection='3d')
+    figure.gca(projection='3d')
 
     x_names = set()
     y_names = set()

--- a/biosimulators_utils/viz/io.py
+++ b/biosimulators_utils/viz/io.py
@@ -116,7 +116,7 @@ def write_plot_3d(plot, data_generator_results, base_path, rel_path, format=VizF
         colormaps (:obj:`list` of :obj:`matplotlib.colors.LinearSegmentedColormap`, optional): colormaps
     """
     figure = pyplot.figure()
-    axes = figure.gca()
+    axes = figure.axes(projection='3d')
 
     x_names = set()
     y_names = set()

--- a/biosimulators_utils/viz/io.py
+++ b/biosimulators_utils/viz/io.py
@@ -116,7 +116,7 @@ def write_plot_3d(plot, data_generator_results, base_path, rel_path, format=VizF
         colormaps (:obj:`list` of :obj:`matplotlib.colors.LinearSegmentedColormap`, optional): colormaps
     """
     figure = pyplot.figure()
-    axes = figure.gca(projection='3d')
+    axes = figure.add_subplot(projection='3d')
 
     x_names = set()
     y_names = set()

--- a/biosimulators_utils/viz/io.py
+++ b/biosimulators_utils/viz/io.py
@@ -116,7 +116,7 @@ def write_plot_3d(plot, data_generator_results, base_path, rel_path, format=VizF
         colormaps (:obj:`list` of :obj:`matplotlib.colors.LinearSegmentedColormap`, optional): colormaps
     """
     figure = pyplot.figure()
-    axes = figure.gca(projection='3d')
+    axes = figure.gca()
 
     x_names = set()
     y_names = set()

--- a/docs-src/requirements.txt
+++ b/docs-src/requirements.txt
@@ -1,3 +1,3 @@
 pydata-sphinx-theme
 sphinx >= 1.8
-sphinxprettysearchresults
+sphinxprettysearchresults @ git+https://github.com/biosimulators/sphinx-pretty-searchresults.git

--- a/tests/combine/test_combine_exec.py
+++ b/tests/combine/test_combine_exec.py
@@ -94,17 +94,6 @@ class ExecCombineTestCase(unittest.TestCase):
                 config.COLLECT_COMBINE_ARCHIVE_RESULTS = True
                 results, _ = exec.exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, config=config)
 
-                # print failing assert variables
-                print('ExecCombineTestCase test 1 assert:')
-                print(f'sed_doc_executer: {sed_doc_executer}'
-                      f'archive_filename: {archive_filename}'
-                      f'out_dir: {out_dir}'
-                      f'config: {config}')
-                print(f'results: {results}')
-                sed_doc_results = SedDocumentResults({
-                    'sim.sedml': ReportResults({'report1': 'ABC', 'report2': 'DEF'})})
-                print(f'SedDocumentResults: {sed_doc_results}')
-
                 self.assertEqual(results, SedDocumentResults({
                     'sim.sedml': ReportResults({
                         'report1': 'ABC',
@@ -220,11 +209,6 @@ class ExecCombineTestCase(unittest.TestCase):
                 config.BUNDLE_OUTPUTS = True
                 config.KEEP_INDIVIDUAL_OUTPUTS = True                
                 exec.exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, config=config)
-
-
-        # print failing assert variables
-        print('ExecCombineTestCase test 2 assert:')
-        print(f'out_dir: {sorted(os.listdir(out_dir))}')
 
         self.assertEqual(sorted(os.listdir(out_dir)), sorted(['reports.zip', 'plots.zip', 'dir1', 'log.yml']))
         self.assertEqual(os.listdir(os.path.join(out_dir, 'dir1')), ['dir2'])

--- a/tests/combine/test_combine_exec.py
+++ b/tests/combine/test_combine_exec.py
@@ -96,12 +96,13 @@ class ExecCombineTestCase(unittest.TestCase):
 
                 # print failing assert variables
                 print('ExecCombineTestCase test 1 assert:')
+                print(f'sed_doc_executer: {sed_doc_executer}'
+                      f'archive_filename: {archive_filename}'
+                      f'out_dir: {out_dir}'
+                      f'config: {config}')
                 print(f'results: {results}')
                 sed_doc_results = SedDocumentResults({
-                    'sim.sedml': ReportResults({
-                        'report1': 'ABC',
-                        'report2': 'DEF',
-                    })})
+                    'sim.sedml': ReportResults({'report1': 'ABC', 'report2': 'DEF'})})
                 print(f'SedDocumentResults: {sed_doc_results}')
 
                 self.assertEqual(results, SedDocumentResults({
@@ -220,6 +221,11 @@ class ExecCombineTestCase(unittest.TestCase):
                 config.KEEP_INDIVIDUAL_OUTPUTS = True                
                 exec.exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, config=config)
 
+
+        # print failing assert variables
+        print('ExecCombineTestCase test 2 assert:')
+        print(f'out_dir: {sorted(os.listdir(out_dir))}')
+
         self.assertEqual(sorted(os.listdir(out_dir)), sorted(['reports.zip', 'plots.zip', 'dir1', 'log.yml']))
         self.assertEqual(os.listdir(os.path.join(out_dir, 'dir1')), ['dir2'])
         self.assertEqual(os.listdir(os.path.join(out_dir, 'dir1', 'dir2')), ['sim.sedml'])
@@ -264,10 +270,6 @@ class ExecCombineTestCase(unittest.TestCase):
                 config.BUNDLE_OUTPUTS = False
                 config.KEEP_INDIVIDUAL_OUTPUTS = False
                 exec.exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, config=config)
-
-        # print failing assert variables
-        print('ExecCombineTestCase test 2 assert:')
-        print(f'out_dir: {sorted(os.listdir(out_dir))}')
 
         self.assertEqual(sorted(os.listdir(out_dir)), sorted(['log.yml', 'extra-file', 'dir1']))
         self.assertEqual(sorted(os.listdir(os.path.join(out_dir, 'dir1'))), sorted(['extra-file']))

--- a/tests/combine/test_combine_exec.py
+++ b/tests/combine/test_combine_exec.py
@@ -93,6 +93,17 @@ class ExecCombineTestCase(unittest.TestCase):
 
                 config.COLLECT_COMBINE_ARCHIVE_RESULTS = True
                 results, _ = exec.exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, config=config)
+
+                # print failing assert variables
+                print('ExecCombineTestCase test 1 assert:')
+                print(f'results: {results}')
+                sed_doc_results = SedDocumentResults({
+                    'sim.sedml': ReportResults({
+                        'report1': 'ABC',
+                        'report2': 'DEF',
+                    })})
+                print(f'SedDocumentResults: {sed_doc_results}')
+
                 self.assertEqual(results, SedDocumentResults({
                     'sim.sedml': ReportResults({
                         'report1': 'ABC',
@@ -253,6 +264,11 @@ class ExecCombineTestCase(unittest.TestCase):
                 config.BUNDLE_OUTPUTS = False
                 config.KEEP_INDIVIDUAL_OUTPUTS = False
                 exec.exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, config=config)
+
+        # print failing assert variables
+        print('ExecCombineTestCase test 2 assert:')
+        print(f'out_dir: {sorted(os.listdir(out_dir))}')
+
         self.assertEqual(sorted(os.listdir(out_dir)), sorted(['log.yml', 'extra-file', 'dir1']))
         self.assertEqual(sorted(os.listdir(os.path.join(out_dir, 'dir1'))), sorted(['extra-file']))
 

--- a/tests/model_lang/bngl/test_bngl_utils.py
+++ b/tests/model_lang/bngl/test_bngl_utils.py
@@ -135,7 +135,7 @@ class BgnlUtilsTestCase(unittest.TestCase):
         self.assertEqual(sims[0].number_of_steps, 4)
 
     def test_get_parameters_variables_for_simulation_with_empty_sample_times(self):
-        with self.assertRaisesRegex(ValueError, 'failed to parse action'):
+        with self.assertRaisesRegex(ValueError, '(F|f)ailed to parse action'):
             get_parameters_variables_outputs_for_simulation(os.path.join(self.FIXTURE_DIRNAME, 'empty-sample-times.bngl'),
                                                             None, UniformTimeCourseSimulation, None)
 

--- a/tests/sedml/test_sedml_validation.py
+++ b/tests/sedml/test_sedml_validation.py
@@ -1485,7 +1485,7 @@ class ValidationTestCase(unittest.TestCase):
         self.assertIn('The syntax', flatten_nested_list_of_strings(validation.validate_calculation(calculation_2)[0]))
 
         calculation_2 = copy.copy(calculation)
-        calculation_2.math = 'a / 1'
+        calculation_2.math = 'a * 1'
         with mock.patch('biosimulators_utils.sedml.math.VALID_MATH_EXPRESSION_NODES', new_callable=mock.PropertyMock(return_value=[])):
             self.assertIn('uses forbidden', flatten_nested_list_of_strings(validation.validate_calculation(calculation_2)[0]))
 

--- a/tests/sedml/test_sedml_validation.py
+++ b/tests/sedml/test_sedml_validation.py
@@ -1487,7 +1487,7 @@ class ValidationTestCase(unittest.TestCase):
         calculation_2 = copy.copy(calculation)
         calculation_2.math = 'a / 1'
         with mock.patch('biosimulators_utils.sedml.math.VALID_MATH_EXPRESSION_NODES', new_callable=mock.PropertyMock(return_value=[])):
-            self.assertIn('is invalid', flatten_nested_list_of_strings(validation.validate_calculation(calculation_2)[0]))
+            self.assertIn('uses forbidden', flatten_nested_list_of_strings(validation.validate_calculation(calculation_2)[0]))
 
         calculation_2 = copy.copy(calculation)
         calculation_2.math = 'a * x + y'


### PR DESCRIPTION
This PR was previously opened with a different branch in PR #121. This PR fixes a long-standing NumPy error in which a slice object can no longer be used as an index, described in issue #123. Instead, I am pulling the ranges out of the slice object and using them directly.

I also fixed some listing errors and matplotlib deprecation errors, but left 4 tests still failing, down from 13 failing before this PR:

FAILED tests/model_lang/bngl/test_bngl_utils.py::BgnlUtilsTestCase::test_get_parameters_variables_for_simulation_with_empty_sample_times - AssertionError: “failed to parse action” does not match “Model file /home/runner/work/Biosimulators_utils/Biosimulators_utils/tests/model_lang/bngl/../../fixtures/bngl/empty-sample-times.bngl is not a valid BNGL or BNGL XML file.
FAILED tests/sedml/test_sedml_validation.py::ValidationTestCase::test_validate_calculation - AssertionError: ‘The syntax’ not found in ‘- The mathematical expression a * is invalid.\n - unexpected EOF while parsing (, line 1)’
FAILED tests/combine/test_combine_exec.py::ExecCombineTestCase::test_1 - AssertionError: None != {‘sim.sedml’: {‘report1’: ‘ABC’, ‘report2’: ‘DEF’}}
FAILED tests/combine/test_combine_exec.py::ExecCombineTestCase::test_2 - AssertionError: Lists differ: [‘log.yml’] != [‘dir1’, ‘log.yml’, ‘plots.zip’, ‘reports.zip’]