### PR TITLE
Iss129

### DIFF
--- a/biosimulators_utils/ref/utils.py
+++ b/biosimulators_utils/ref/utils.py
@@ -266,6 +266,8 @@ def get_pubmed_central_open_access_graphics(id, dirname, session=requests):
                 filename=os.path.join(dirname, id, graphic.attrib['{{{}}}href'.format(graphic.nsmap['xlink'])] + ".jpg"),
             ))
 
+    os.remove(tgz_filename)
+
     return graphics
 
 


### PR DESCRIPTION
As asked in issue 129, this PR adds code to remove the tar gz after unzipping in the function get_pubmed_central_open_access_graphics. The filename is already stored in tgz_filename, so only 1 line of code was needed. 