### PR TITLE
Refactor Stdout capturer to handle serialization.

### DIFF
--- a/biosimulators_utils/__init__.py
+++ b/biosimulators_utils/__init__.py
@@ -1,2 +1,2 @@
-from ._version import __version__  # noqa: F401
+from biosimulators_utils._version import __version__  # noqa: F401
 # :obj:`str`: version

--- a/biosimulators_utils/__main__.py
+++ b/biosimulators_utils/__main__.py
@@ -6,11 +6,11 @@
 :License: MIT
 """
 
-from .combine.data_model import CombineArchiveContentFormat
-from .config import get_config
-from .sedml.data_model import ModelLanguage, OneStepSimulation, SteadyStateSimulation, UniformTimeCourseSimulation
-from .utils.core import flatten_nested_list_of_strings
-from .warnings import warn, BioSimulatorsWarning
+from biosimulators_utils.combine.data_model import CombineArchiveContentFormat
+from biosimulators_utils.config import get_config
+from biosimulators_utils.sedml.data_model import ModelLanguage, OneStepSimulation, SteadyStateSimulation, UniformTimeCourseSimulation
+from biosimulators_utils.utils.core import flatten_nested_list_of_strings
+from biosimulators_utils.warnings import warn, BioSimulatorsWarning
 import biosimulators_utils
 import cement
 import json

--- a/biosimulators_utils/combine/exec.py
+++ b/biosimulators_utils/combine/exec.py
@@ -320,4 +320,4 @@ def exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, appl
         log.export()
 
     # return results and log
-    return (results, log)
+    return (results, log) # noqa W292

--- a/biosimulators_utils/combine/exec.py
+++ b/biosimulators_utils/combine/exec.py
@@ -98,7 +98,7 @@ def exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, appl
         config = get_config()
 
     output_capturer = output_capturer or StandardOutputErrorCapturer(relay=True, level=log_level, disabled=not config.LOG)
-    
+
     with output_capturer as archive_captured:
         verbose = config.VERBOSE
 

--- a/biosimulators_utils/combine/exec.py
+++ b/biosimulators_utils/combine/exec.py
@@ -39,7 +39,8 @@ def exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, appl
                                sed_doc_executer_supported_features=(Task, Report, DataSet, Plot2D, Curve, Plot3D, Surface),
                                sed_doc_executer_logged_features=(Task, Report, DataSet, Plot2D, Curve, Plot3D, Surface),
                                log_level=StandardOutputErrorCapturerLevel.c,
-                               config=None):
+                               config=None,
+                               output_capturer=None):
     """ Execute the SED-ML files in a COMBINE/OMEX archive (execute tasks and save outputs)
 
     Args:

--- a/biosimulators_utils/combine/exec.py
+++ b/biosimulators_utils/combine/exec.py
@@ -40,7 +40,7 @@ def exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, appl
                                sed_doc_executer_logged_features=(Task, Report, DataSet, Plot2D, Curve, Plot3D, Surface),
                                log_level=StandardOutputErrorCapturerLevel.c,
                                config=None,
-                               output_capturer=None):
+                               output_capturer: StandardOutputErrorCapturer = None):
     """ Execute the SED-ML files in a COMBINE/OMEX archive (execute tasks and save outputs)
 
     Args:
@@ -97,7 +97,9 @@ def exec_sedml_docs_in_archive(sed_doc_executer, archive_filename, out_dir, appl
     if not config:
         config = get_config()
 
-    with StandardOutputErrorCapturer(relay=True, level=log_level, disabled=not config.LOG) as archive_captured:
+    output_capturer = output_capturer or StandardOutputErrorCapturer(relay=True, level=log_level, disabled=not config.LOG)
+    
+    with output_capturer as archive_captured:
         verbose = config.VERBOSE
 
         # initialize status and output

--- a/biosimulators_utils/combine/exec.py
+++ b/biosimulators_utils/combine/exec.py
@@ -6,22 +6,22 @@
 :License: MIT
 """
 
-from ..archive.io import ArchiveWriter
-from ..archive.utils import build_archive_from_paths
-from ..config import get_config, Config  # noqa: F401
-from ..log.data_model import Status, CombineArchiveLog, StandardOutputErrorCapturerLevel  # noqa: F401
-from ..log.utils import init_combine_archive_log, get_summary_combine_archive_log, StandardOutputErrorCapturer
-from ..report.data_model import VariableResults, ReportFormat, SedDocumentResults  # noqa: F401
-from ..sedml.data_model import (SedDocument, Task, Output, Report, DataSet, Plot2D, Curve,  # noqa: F401
+from biosimulators_utils.archive.io import ArchiveWriter
+from biosimulators_utils.archive.utils import build_archive_from_paths
+from biosimulators_utils.config import get_config, Config  # noqa: F401
+from biosimulators_utils.log.data_model import Status, CombineArchiveLog, StandardOutputErrorCapturerLevel  # noqa: F401
+from biosimulators_utils.log.utils import init_combine_archive_log, get_summary_combine_archive_log, StandardOutputErrorCapturer
+from biosimulators_utils.report.data_model import VariableResults, ReportFormat, SedDocumentResults  # noqa: F401
+from biosimulators_utils.sedml.data_model import (SedDocument, Task, Output, Report, DataSet, Plot2D, Curve,  # noqa: F401
                                 Plot3D, Surface, Variable)
-from ..utils.core import flatten_nested_list_of_strings
-from ..warnings import warn, BioSimulatorsWarning
-from .exceptions import CombineArchiveExecutionError, NoSedmlError
-from .data_model import CombineArchive
-from .io import CombineArchiveReader
-from .utils import get_sedml_contents, get_summary_sedml_contents
-from .validation import validate
-from ..viz.data_model import VizFormat  # noqa: F401
+from biosimulators_utils.utils.core import flatten_nested_list_of_strings
+from biosimulators_utils.warnings import warn, BioSimulatorsWarning
+from biosimulators_utils.combine.exceptions import CombineArchiveExecutionError, NoSedmlError
+from biosimulators_utils.combine.data_model import CombineArchive
+from biosimulators_utils.combine.io import CombineArchiveReader
+from biosimulators_utils.combine.utils import get_sedml_contents, get_summary_sedml_contents
+from biosimulators_utils.combine.validation import validate
+from biosimulators_utils.viz.data_model import VizFormat  # noqa: F401
 import copy
 import datetime
 import glob

--- a/biosimulators_utils/combine/exec.py
+++ b/biosimulators_utils/combine/exec.py
@@ -13,7 +13,7 @@ from biosimulators_utils.log.data_model import Status, CombineArchiveLog, Standa
 from biosimulators_utils.log.utils import init_combine_archive_log, get_summary_combine_archive_log, StandardOutputErrorCapturer
 from biosimulators_utils.report.data_model import VariableResults, ReportFormat, SedDocumentResults  # noqa: F401
 from biosimulators_utils.sedml.data_model import (SedDocument, Task, Output, Report, DataSet, Plot2D, Curve,  # noqa: F401
-                                Plot3D, Surface, Variable)
+                                                  Plot3D, Surface, Variable)
 from biosimulators_utils.utils.core import flatten_nested_list_of_strings
 from biosimulators_utils.warnings import warn, BioSimulatorsWarning
 from biosimulators_utils.combine.exceptions import CombineArchiveExecutionError, NoSedmlError

--- a/biosimulators_utils/config.py
+++ b/biosimulators_utils/config.py
@@ -6,9 +6,9 @@
 :License: MIT
 """
 
-from .omex_meta.data_model import OmexMetadataInputFormat, OmexMetadataOutputFormat, OmexMetadataSchema
-from .report.data_model import ReportFormat  # noqa: F401
-from .viz.data_model import VizFormat  # noqa: F401
+from biosimulators_utils.omex_meta.data_model import OmexMetadataInputFormat, OmexMetadataOutputFormat, OmexMetadataSchema
+from biosimulators_utils.report.data_model import ReportFormat  # noqa: F401
+from biosimulators_utils.viz.data_model import VizFormat  # noqa: F401
 from kisao import AlgorithmSubstitutionPolicy  # noqa: F401
 import appdirs
 import enum

--- a/biosimulators_utils/log/data_model.py
+++ b/biosimulators_utils/log/data_model.py
@@ -6,7 +6,7 @@
 :License: MIT
 """
 
-from ..config import get_config
+from biosimulators_utils.config import get_config
 import enum
 import os
 import yaml

--- a/biosimulators_utils/log/utils.py
+++ b/biosimulators_utils/log/utils.py
@@ -13,7 +13,7 @@ from biosimulators_utils.sedml.data_model import SedDocument, Task, Output, Repo
 from biosimulators_utils.sedml.io import SedmlSimulationReader
 from biosimulators_utils.warnings import warn
 from biosimulators_utils.log.data_model import (Status, CombineArchiveLog, SedDocumentLog,  # noqa: F401
-                                                TaskLog, OutputLog, ReportLog, Plot2DLog, Plot3DLog, # noqa: W291
+                                                TaskLog, OutputLog, ReportLog, Plot2DLog, Plot3DLog,  # noqa: W291
                                                 StandardOutputErrorCapturerLevel)
 from biosimulators_utils.log.warnings import StandardOutputNotLoggedWarning
 try:

--- a/biosimulators_utils/log/utils.py
+++ b/biosimulators_utils/log/utils.py
@@ -332,7 +332,7 @@ class StandardOutputErrorCapturer(contextlib.AbstractContextManager):
             else:
                 sys.stdout = self._stdout
                 sys.stderr = self._stderr
-                
+             
     def __getstate__(self):
         """Get the state for pickling."""
         if self.level >= StandardOutputErrorCapturerLevel.c and capturer:
@@ -343,7 +343,7 @@ class StandardOutputErrorCapturer(contextlib.AbstractContextManager):
             return state
         else:
             return self.__dict__
-        
+    
     def __setstate__(self, state):
         """Set the state for unpickling."""
         self.__dict__.update(state)

--- a/biosimulators_utils/log/utils.py
+++ b/biosimulators_utils/log/utils.py
@@ -13,8 +13,8 @@ from biosimulators_utils.sedml.data_model import SedDocument, Task, Output, Repo
 from biosimulators_utils.sedml.io import SedmlSimulationReader
 from biosimulators_utils.warnings import warn
 from biosimulators_utils.log.data_model import (Status, CombineArchiveLog, SedDocumentLog,  # noqa: F401
-                         TaskLog, OutputLog, ReportLog, Plot2DLog, Plot3DLog,
-                         StandardOutputErrorCapturerLevel)
+                                                TaskLog, OutputLog, ReportLog, Plot2DLog, Plot3DLog, 
+                                                StandardOutputErrorCapturerLevel)
 from biosimulators_utils.log.warnings import StandardOutputNotLoggedWarning
 try:
     import capturer

--- a/biosimulators_utils/log/utils.py
+++ b/biosimulators_utils/log/utils.py
@@ -332,7 +332,7 @@ class StandardOutputErrorCapturer(contextlib.AbstractContextManager):
             else:
                 sys.stdout = self._stdout
                 sys.stderr = self._stderr
-             
+# noqa: W293            
     def __getstate__(self):
         """Get the state for pickling."""
         if self.level >= StandardOutputErrorCapturerLevel.c and capturer:
@@ -343,7 +343,7 @@ class StandardOutputErrorCapturer(contextlib.AbstractContextManager):
             return state
         else:
             return self.__dict__
-    
+# noqa: W293    
     def __setstate__(self, state):
         """Set the state for unpickling."""
         self.__dict__.update(state)

--- a/biosimulators_utils/log/utils.py
+++ b/biosimulators_utils/log/utils.py
@@ -324,7 +324,7 @@ class StandardOutputErrorCapturer(contextlib.AbstractContextManager):
                 sys.stderr = self
         return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         """ Exit a context """
         if not self.disabled:
             if self.level >= StandardOutputErrorCapturerLevel.c and capturer:

--- a/biosimulators_utils/log/utils.py
+++ b/biosimulators_utils/log/utils.py
@@ -332,7 +332,7 @@ class StandardOutputErrorCapturer(contextlib.AbstractContextManager):
             else:
                 sys.stdout = self._stdout
                 sys.stderr = self._stderr
-# noqa: W293            
+# noqa            
     def __getstate__(self):
         """Get the state for pickling."""
         if self.level >= StandardOutputErrorCapturerLevel.c and capturer:
@@ -343,7 +343,7 @@ class StandardOutputErrorCapturer(contextlib.AbstractContextManager):
             return state
         else:
             return self.__dict__
-# noqa: W293    
+# noqa   
     def __setstate__(self, state):
         """Set the state for unpickling."""
         self.__dict__.update(state)

--- a/biosimulators_utils/log/utils.py
+++ b/biosimulators_utils/log/utils.py
@@ -13,7 +13,7 @@ from biosimulators_utils.sedml.data_model import SedDocument, Task, Output, Repo
 from biosimulators_utils.sedml.io import SedmlSimulationReader
 from biosimulators_utils.warnings import warn
 from biosimulators_utils.log.data_model import (Status, CombineArchiveLog, SedDocumentLog,  # noqa: F401
-                                                TaskLog, OutputLog, ReportLog, Plot2DLog, Plot3DLog, 
+                                                TaskLog, OutputLog, ReportLog, Plot2DLog, Plot3DLog, # noqa: W291
                                                 StandardOutputErrorCapturerLevel)
 from biosimulators_utils.log.warnings import StandardOutputNotLoggedWarning
 try:

--- a/biosimulators_utils/warnings.py
+++ b/biosimulators_utils/warnings.py
@@ -6,7 +6,7 @@
 :License: MIT
 """
 
-from .config import Colors
+from biosimulators_utils.config import Colors
 import termcolor
 import warnings
 


### PR DESCRIPTION
**What new features does this PR implement?**
Please summarize the features that this PR implements. As relevant, please indicate the issues that the PR closes.

* Implements `__getstate__` and `__setstate__` methods (`@getter`, `@setter`) to override pickling that is inherent to `StandardOutputCapturer()` call in `biosimulators_utils.combine.exec.exec_sedml_docs_in_archive()`.
* Adds `StandardOutputErrorCapturer` as being `typing.Optional` in `combine` subdir methods. Closes biosimulators-copasi number 56.
* Adds absolute imports to packages

**What bugs does this PR fix?**
Please summarize the bugs that this PR fixes. As relevant, please indicate the issues that the PR closes.

* The "hidden" error of `TypeError: cannot pickle '_io.BufferedReader' object` that is exposed during evocation of `capturer`.
* 

**Does this PR introduce any additional changes?**
Please summarize any additional changes that this PR introduces.

* 
* 

**How have you tested this PR?**
Please summarize the tests that you implemented to test this PR.

* 
* 

**Additional information**
Please describe any information needed to review this PR.
