### PR TITLE
Remove deprecated NumPy string dtype alias

### DIFF
--- a/biosimulators_utils/report/io.py
+++ b/biosimulators_utils/report/io.py
@@ -77,7 +77,7 @@ class ReportWriter(object):
                     data_set_shapes.append('')
                 else:
                     data_set_dtype = data_set_result.dtype
-                    if data_set_dtype in [numpy.dtype('object'), numpy.dtype('void'), numpy.dtype('S'), numpy.dtype('a')]:
+                    if data_set_dtype in [numpy.dtype('object'), numpy.dtype('void'), numpy.dtype('S')]:
                         msg = 'NumPy dtype should be a specific type such as `float64` or `int64` not `{}`.'.format(data_set_dtype.name)
                         raise TypeError(msg)
                     data_set_data_types.append(data_set_dtype.name)


### PR DESCRIPTION
**What new features does this PR implement?**

None.

**What bugs does this PR fix?**

* Removes the deprecated NumPy dtype alias `numpy.dtype(a)` from report dtype validation (closes #163).

**Does this PR introduce any additional changes?**

None.

**How have you tested this PR?**

Not run locally.

Static validation:

* `git diff --check HEAD~1..HEAD`
* `git show --stat --oneline --summary HEAD`
* Targeted source inspection confirmed `numpy.dtype(a)` is no longer used in `biosimulators_utils/report/io.py` and `numpy.dtype(S)` remains in the validation list.

Remote CI:

* `Continuous integration` run 26416898040 is `action_required` with no jobs or logs available yet.

**Additional information**

The change is limited to replacing the deprecated alias usage with the existing `S` bytestring dtype entry that was already checked on the same line.