### PR TITLE
Validate change/variable targets against the model they reference

### DIFF
--- a/biosimulators_utils/sedml/validation.py
+++ b/biosimulators_utils/sedml/validation.py
@@ -356,7 +356,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                                     variable.model.language, variable.model.id,
                                     check_in_model_source=validate_targets_with_model_sources,
                                     model_change=variable.model.has_structural_changes(),
-                                    model_etree=model_etrees.get(model, None),
+                                    model_etree=model_etrees.get(variable.model, None),
                                 )
                                 variable_errors.extend(temp_errors)
                                 variable_warnings.extend(temp_warnings)
@@ -506,7 +506,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                                 ModelChange, change.model.language, change.model.id,
                                 check_in_model_source=validate_targets_with_model_sources,
                                 model_change=change.model and change.model.has_structural_changes(),
-                                model_etree=model_etrees.get(model, None),
+                                model_etree=model_etrees.get(change.model, None),
                             )
                             change_errors.extend(temp_errors)
                             change_warnings.extend(temp_warnings)
@@ -548,7 +548,7 @@ def validate_doc(doc, working_dir, validate_semantics=True,
                                 Calculation, variable.model.language, variable.model.id,
                                 check_in_model_source=validate_targets_with_model_sources,
                                 model_change=change.model and change.model.has_structural_changes(),
-                                model_etree=model_etrees.get(model, None),
+                                model_etree=model_etrees.get(variable.model, None),
                             )
                             variable_errors.extend(temp_errors)
                             variable_warnings.extend(temp_warnings)

--- a/tests/sedml/test_sedml_validation.py
+++ b/tests/sedml/test_sedml_validation.py
@@ -1945,6 +1945,59 @@ class ValidationTestCase(unittest.TestCase):
         self.assertIn('The following tasks do not contribute', flatten_nested_list_of_strings(warnings))
 
 
+    def test_validate_repeated_task_xpaths_use_the_referenced_model(self):
+        # Two models with distinctly-named parameters, so a target that resolves against one
+        # cannot resolve against the other.
+        sbml = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">'
+            '<model id="{model}"><listOfParameters>'
+            '<parameter id="{parameter}" value="1" constant="true"/>'
+            '</listOfParameters></model></sbml>'
+        )
+        for model_id, parameter in [('model1', 'p1'), ('model2', 'p2')]:
+            with open(os.path.join(self.dirname, model_id + '.xml'), 'w') as file:
+                file.write(sbml.format(model=model_id, parameter=parameter))
+
+        def build_doc(model_order):
+            models = {
+                model_id: data_model.Model(id=model_id, source=model_id + '.xml',
+                                           language=data_model.ModelLanguage.SBML.value)
+                for model_id in ['model1', 'model2']
+            }
+            doc = data_model.SedDocument()
+            doc.models = [models[model_id] for model_id in model_order]
+            doc.simulations.append(data_model.SteadyStateSimulation(
+                id='sim', algorithm=data_model.Algorithm(kisao_id='KISAO_0000019')))
+            doc.tasks.append(data_model.Task(id='task1', model=models['model1'], simulation=doc.simulations[0]))
+            repeated_task = data_model.RepeatedTask(
+                id='task2',
+                sub_tasks=[data_model.SubTask(order=1, task=doc.tasks[0])],
+                ranges=[data_model.VectorRange(id='range1', values=[1., 2.])],
+            )
+            repeated_task.range = repeated_task.ranges[0]
+            repeated_task.changes.append(
+                data_model.SetValueComputeModelChange(
+                    model=models['model1'],
+                    # `p1` is a parameter of model1, which is the model this change references
+                    target="/sbml:sbml/sbml:model/sbml:listOfParameters/sbml:parameter[@id='p1']/@value",
+                    target_namespaces={'sbml': 'http://www.sbml.org/sbml/level3/version2/core'},
+                    range=repeated_task.ranges[0],
+                    math='range1',
+                )
+            )
+            doc.tasks.append(repeated_task)
+            return doc
+
+        # The target must be checked against the model the change references, wherever that
+        # model happens to sit in the document. Previously every change was checked against
+        # the last model in `doc.models`, so this passed in one order and failed in the other.
+        for model_order in [['model1', 'model2'], ['model2', 'model1']]:
+            errors, _ = validation.validate_doc(build_doc(model_order), self.dirname,
+                                                validate_models_with_languages=False)
+            self.assertEqual(errors, [], 'unexpected errors with model order {}'.format(model_order))
+
+
 if __name__ == "__main__":
     import pytest
     pytest.main(["test_sedml_validation.py"])


### PR DESCRIPTION
Fixes #167.

`validate_doc` reports valid `repeatedTask` `setValue` targets as invalid, because the XPath is evaluated against **the last `<model>` in the document** rather than the model the change references.

## Cause

`model_etrees` is built in `for model in doc.models:` (L131, rebound at L229). Three later `validate_target(...)` calls then read `model_etrees.get(model, None)` — the leaked loop variable, which by then is always the last model — where they mean the model belonging to the change or variable being validated:

| line | context | now passes |
|------|---------|-----------|
| 359 | repeated-task change *variable* | `model_etrees.get(variable.model, None)` |
| 509 | repeated-task `setValue` *change target* | `model_etrees.get(change.model, None)` |
| 551 | `setValue` *variable* | `model_etrees.get(variable.model, None)` |

Every *other* argument at those call sites already comes from `change.model` / `variable.model` — only the etree was taken from the stale name. That is why the message names a model that was never searched, and the element it claims is missing is plainly present in the named model's source.

L190 and L1408 also read `model_etrees.get(model, ...)` but use genuine loop variables; they are untouched.

## Test

`test_validate_repeated_task_xpaths_use_the_referenced_model` validates one document twice, swapping **only** the order of two models in `doc.models`. The change references the same model and carries the same target both times, so both orderings must be valid.

On `dev` the new test fails in one ordering with exactly the reported message:

```
AssertionError: Lists differ: [['Task `task2` is invalid.', ...
-  'does not match any elements of model `model1`.']]]]]]]] : unexpected errors with model order ['model1', 'model2']
```

and passes in the other — the ordering alone decides it. With the fix both orderings pass.

The existing repeated-task fixtures (`BIOMD0000000297_repeat_*.sedml`) all have a **single** model, where the leaked variable happens to equal the correct one, which is why this went unnoticed.

## Verification

`tests/sedml/` run against this branch versus the same clone with only the `validation.py` change reverted:

| | failures |
|---|---|
| without fix | 4 — 3 pre-existing + the new test |
| with fix | 3 — the 3 pre-existing only |

The 3 pre-existing failures (`test_validate_model_with_language`, `test_get_parameters_variables_for_simulation`, `test_build_combine_archive_for_model_xpp_with_plot`) are missing optional dependencies in my environment — `ModuleNotFoundError: No module named 'libcellml'` and XPP — and fail identically before and after. Nothing else changes.

## Deliberately not included

Two adjacent points raised in #167 are left out, since they are behaviour calls rather than clear bugs and I did not want to bundle them:

- **L551** passes `model_change=change.model and change.model.has_structural_changes()` where its sibling at L359 uses `variable.model`. Since the target validated there is `variable.target`, `variable.model` looks right, but it can turn warnings into errors for some documents.
- **`Model.has_structural_changes()`** returns `True` for `ModelAttributeChange`, contradicting its docstring (add/replace/remove only). This is what demotes genuine XPath misses to warnings for any model carrying changes, so it masked half of this bug — but tightening it would surface errors in documents that validate today.

Happy to fold either in, or open them separately, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvqmME7MkRUNEYje5HpiLt
